### PR TITLE
feat: expose maintainers, maintainer_count, last_publish in API

### DIFF
--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -8,9 +8,9 @@ use axum::{
     Json,
 };
 use common::{
-    AgenticThreatSummary, BulkLookupRequest, CveSummary, InstallScripts, PackageCapabilities,
-    PackageListItem, PackageListResponse, PackageResponse, PaginationParams, PublisherInfo,
-    Registry, ScanJob, ScanPriority, ScanRequest, ScanRequestResponse,
+    AgenticThreatSummary, BulkLookupRequest, CveSummary, InstallScripts, MaintainerInfo,
+    PackageCapabilities, PackageListItem, PackageListResponse, PackageResponse, PaginationParams,
+    PublisherInfo, Registry, ScanJob, ScanPriority, ScanRequest, ScanRequestResponse,
 };
 use serde_json::json;
 use std::io::Write;
@@ -125,6 +125,12 @@ pub async fn get_package(
     let capabilities: PackageCapabilities =
         serde_json::from_value(package.capabilities.clone()).unwrap_or_default();
 
+    // Parse maintainers from JSONB
+    let maintainers: Option<Vec<MaintainerInfo>> = package
+        .maintainers
+        .as_ref()
+        .and_then(|m| serde_json::from_value(m.clone()).ok());
+
     let response = PackageResponse {
         name: package.name,
         version: package.version,
@@ -137,6 +143,9 @@ pub async fn get_package(
             verified,
         }),
         weekly_downloads: package.weekly_downloads.map(|d| d as u64),
+        maintainers,
+        maintainer_count: package.maintainer_count.map(|c| c as u32),
+        last_publish: package.last_publish,
         install_scripts: InstallScripts::default(), // TODO: store in DB
         cves: cves
             .into_iter()
@@ -212,6 +221,12 @@ pub async fn get_package_version(
     let capabilities: PackageCapabilities =
         serde_json::from_value(package.capabilities.clone()).unwrap_or_default();
 
+    // Parse maintainers from JSONB
+    let maintainers: Option<Vec<MaintainerInfo>> = package
+        .maintainers
+        .as_ref()
+        .and_then(|m| serde_json::from_value(m.clone()).ok());
+
     let response = PackageResponse {
         name: package.name,
         version: package.version,
@@ -224,6 +239,9 @@ pub async fn get_package_version(
             verified,
         }),
         weekly_downloads: package.weekly_downloads.map(|d| d as u64),
+        maintainers,
+        maintainer_count: package.maintainer_count.map(|c| c as u32),
+        last_publish: package.last_publish,
         install_scripts: InstallScripts::default(),
         cves: cves
             .into_iter()
@@ -307,6 +325,12 @@ pub async fn bulk_lookup(
         let capabilities: PackageCapabilities =
             serde_json::from_value(package.capabilities.clone()).unwrap_or_default();
 
+        // Parse maintainers from JSONB
+        let maintainers: Option<Vec<MaintainerInfo>> = package
+            .maintainers
+            .as_ref()
+            .and_then(|m| serde_json::from_value(m.clone()).ok());
+
         responses.push(PackageResponse {
             name: package.name,
             version: package.version,
@@ -319,6 +343,9 @@ pub async fn bulk_lookup(
                 verified,
             }),
             weekly_downloads: package.weekly_downloads.map(|d| d as u64),
+            maintainers,
+            maintainer_count: package.maintainer_count.map(|c| c as u32),
+            last_publish: package.last_publish,
             install_scripts: InstallScripts::default(),
             cves: cves
                 .into_iter()

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -91,6 +91,8 @@ pub struct Package {
     pub maintainer_count: Option<i32>,
     pub last_publish: Option<DateTime<Utc>>,
     pub capabilities: serde_json::Value,
+    /// Maintainers list as JSON array
+    pub maintainers: Option<serde_json::Value>,
     pub skill_md: Option<String>,
     pub scanned_at: DateTime<Utc>,
     pub scan_version: Option<String>,
@@ -289,6 +291,13 @@ pub struct PublisherInfo {
     pub verified: bool,
 }
 
+/// Maintainer information for API responses
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintainerInfo {
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
 /// Install script information
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InstallScripts {
@@ -360,6 +369,9 @@ pub struct PackageResponse {
     pub trust_score: Option<u8>,
     pub publisher: Option<PublisherInfo>,
     pub weekly_downloads: Option<u64>,
+    pub maintainers: Option<Vec<MaintainerInfo>>,
+    pub maintainer_count: Option<u32>,
+    pub last_publish: Option<DateTime<Utc>>,
     pub install_scripts: InstallScripts,
     pub cves: Vec<CveSummary>,
     pub agentic_threats: Vec<AgenticThreatSummary>,


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

Add missing fields to PackageResponse that were stored in DB but not returned by the API:

- maintainers: list of maintainer name/email from npm
- maintainer_count: number of maintainers
- last_publish: timestamp of last publish

Also adds MaintainerInfo struct for the API response.

## Test plan

- [x] Tests pass locally
- [x] Tested manually
