### PR TITLE
feat: migrate from skills to AGENTS.md docs index

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use colored::Colorize;
 use common::RiskLevel;
 use dialoguer::Confirm;
+use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 
 /// Parse a package string into name and optional version
@@ -35,9 +37,6 @@ pub async fn run(
     yolo: bool,
     strict: bool,
 ) -> Result<()> {
-    // Ensure AGENTS.md exists with sus instructions (only runs once)
-    ensure_agents_md();
-
     for package_spec in &packages {
         let (name, version) = parse_package_spec(package_spec);
         let display_name = if let Some(v) = version {
@@ -152,9 +151,20 @@ pub async fn run(
         install_package(package_spec).await?;
         println!("{}", "📦 installed".green());
 
-        // Save agent skills to all coding agent folders
-        if let Some(skill_md) = &assessment.skill_md {
-            save_agent_skills(name, skill_md);
+        // Save package documentation and update AGENTS.md index
+        if let Some(package_doc) = &assessment.skill_md {
+            // Extract description for the index
+            let description = extract_description(&assessment);
+
+            // Save doc file
+            if let Err(e) = save_package_doc(name, package_doc) {
+                tracing::debug!("Failed to save package doc: {}", e);
+            }
+
+            // Update AGENTS.md index
+            if let Err(e) = update_agents_md_index(name, &assessment.version, &description) {
+                tracing::debug!("Failed to update AGENTS.md index: {}", e);
+            }
         }
     }
 
@@ -195,112 +205,19 @@ fn detect_package_manager() -> String {
     "npm".to_string()
 }
 
-/// Coding agent root folders
-const AGENT_ROOTS: &[&str] = &[
-    ".agents",
-    ".claude",
-    ".codex",
-    ".cursor",
-    ".gemini",
-    ".opencode",
-    ".windsurf",
-];
+// =============================================================================
+// Package Documentation Storage (.sus-docs/)
+// =============================================================================
 
-/// AGENTS.md file path
-const AGENTS_MD_PATH: &str = "AGENTS.md";
+/// Directory for package documentation
+const DOCS_DIR: &str = ".sus-docs";
 
-/// Marker to detect if AGENTS.md has already been patched with sus instructions
-const SUS_MARKER: &str = "## sus Package Security";
-
-/// Content to add to AGENTS.md
-const SUS_AGENTS_SECTION: &str = r#"## sus Package Security
-
-When installing packages in this project, use `sus` instead of directly using package managers (npm, pip, cargo, etc.):
-
-- Install packages: `sus add <package-name>`
-- Check a package: `sus check <package-name>`
-
-sus performs security analysis before installation. After installing a package, check the skills folder in your agent's directory (e.g., `.cursor/skills/`, `.claude/skills/`) for package-specific usage guidance.
-"#;
-
-/// Ensure AGENTS.md exists and contains sus instructions
-/// Creates the file if it doesn't exist, or patches it if the sus section is missing
-fn ensure_agents_md() {
-    ensure_agents_md_at_path(std::path::Path::new(AGENTS_MD_PATH));
-}
-
-/// Result of ensuring AGENTS.md
-#[derive(Debug, PartialEq)]
-enum AgentsMdResult {
-    /// File was created
-    Created,
-    /// File was patched (sus section added)
-    Patched,
-    /// File already had sus section
-    AlreadyPatched,
-    /// Error occurred
-    Error,
-}
-
-/// Internal implementation that accepts a path for testability
-fn ensure_agents_md_at_path(agents_path: &std::path::Path) -> AgentsMdResult {
-    use std::fs;
-
-    // Check if file exists
-    if agents_path.exists() {
-        // Read existing content
-        match fs::read_to_string(agents_path) {
-            Ok(content) => {
-                // Check if already patched
-                if content.contains(SUS_MARKER) {
-                    // Already patched, nothing to do
-                    return AgentsMdResult::AlreadyPatched;
-                }
-
-                // Append sus section to existing file
-                let new_content = if content.ends_with('\n') {
-                    format!("{}\n{}", content, SUS_AGENTS_SECTION)
-                } else {
-                    format!("{}\n\n{}", content, SUS_AGENTS_SECTION)
-                };
-
-                if let Err(e) = fs::write(agents_path, new_content) {
-                    tracing::warn!("Failed to patch AGENTS.md: {}", e);
-                    AgentsMdResult::Error
-                } else {
-                    println!(
-                        "   {} patched {} with sus instructions",
-                        "📝".cyan(),
-                        agents_path.display()
-                    );
-                    AgentsMdResult::Patched
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Failed to read AGENTS.md: {}", e);
-                AgentsMdResult::Error
-            }
-        }
-    } else {
-        // Create new AGENTS.md with sus section
-        let content = format!("# AGENTS.md\n\n{}", SUS_AGENTS_SECTION);
-
-        if let Err(e) = fs::write(agents_path, content) {
-            tracing::warn!("Failed to create AGENTS.md: {}", e);
-            AgentsMdResult::Error
-        } else {
-            println!(
-                "   {} created {} with sus instructions",
-                "📝".cyan(),
-                agents_path.display()
-            );
-            AgentsMdResult::Created
-        }
-    }
-}
-
-/// Convert package name to valid skill name (per Agent Skills spec)
-fn to_skill_name(package: &str) -> String {
+/// Convert package name to valid doc filename
+/// - Lowercase only
+/// - Alphanumeric and hyphens only
+/// - No consecutive hyphens
+/// - Can't start or end with hyphen
+pub fn to_doc_name(package: &str) -> String {
     let mut name: String = package
         .to_lowercase()
         .chars()
@@ -327,45 +244,230 @@ fn to_skill_name(package: &str) -> String {
     }
 }
 
-/// Save agent skill to existing coding agent folders only
-/// Follows Agent Skills spec: {agent}/skills/{skill-name}/SKILL.md
-fn save_agent_skills(package_name: &str, skill_content: &str) {
-    use std::path::Path;
+/// Save package documentation to .sus-docs/ directory
+fn save_package_doc(package_name: &str, doc_content: &str) -> Result<()> {
+    let doc_name = to_doc_name(package_name);
+    let doc_path = format!("{}/{}.md", DOCS_DIR, doc_name);
 
-    let skill_name = to_skill_name(package_name);
-    let mut saved_count = 0;
+    std::fs::create_dir_all(DOCS_DIR)?;
+    std::fs::write(&doc_path, doc_content)?;
 
-    for agent_root in AGENT_ROOTS {
-        // Only write to agent folders that already exist
-        if !Path::new(agent_root).exists() {
-            continue;
-        }
+    println!("   {} saved docs to {}", "📄".cyan(), doc_path);
+    Ok(())
+}
 
-        let skills_dir = format!("{}/skills", agent_root);
-        let skill_dir = format!("{}/{}", skills_dir, skill_name);
-        let skill_path = format!("{}/SKILL.md", skill_dir);
-
-        // Create the skill directory structure
-        if let Err(e) = std::fs::create_dir_all(&skill_dir) {
-            tracing::debug!("Failed to create {}: {}", skill_dir, e);
-            continue;
-        }
-
-        if let Err(e) = std::fs::write(&skill_path, skill_content) {
-            tracing::debug!("Failed to write {}: {}", skill_path, e);
-        } else {
-            saved_count += 1;
+/// Extract a one-line description from the assessment for the index
+fn extract_description(assessment: &common::PackageResponse) -> String {
+    // Try to get description from the first line of skill_md if available
+    if let Some(doc) = &assessment.skill_md {
+        // Skip the header line and badge, find first real content
+        for line in doc.lines().skip(4) {
+            let trimmed = line.trim();
+            if !trimmed.is_empty()
+                && !trimmed.starts_with('#')
+                && !trimmed.starts_with('!')
+                && !trimmed.starts_with("```")
+            {
+                // Truncate to 80 chars
+                let desc = if trimmed.len() > 80 {
+                    format!("{}...", &trimmed[..77])
+                } else {
+                    trimmed.to_string()
+                };
+                return desc;
+            }
         }
     }
 
-    if saved_count > 0 {
-        println!(
-            "   {} saved skill to {} agent folder{}",
-            "📚".cyan(),
-            saved_count,
-            if saved_count == 1 { "" } else { "s" }
-        );
+    // Fallback to generic description
+    format!("{} package", assessment.name)
+}
+
+// =============================================================================
+// AGENTS.md Index Management
+// =============================================================================
+
+/// AGENTS.md file path
+const AGENTS_MD_PATH: &str = "AGENTS.md";
+
+/// Markers for the sus docs section in AGENTS.md
+const SUS_INDEX_START: &str = "<!-- sus-docs-start -->";
+const SUS_INDEX_END: &str = "<!-- sus-docs-end -->";
+
+/// Update AGENTS.md with package index entry
+pub fn update_agents_md_index(name: &str, version: &str, description: &str) -> Result<()> {
+    update_agents_md_index_at_path(Path::new(AGENTS_MD_PATH), name, version, description)
+}
+
+/// Internal implementation that accepts a path for testability
+fn update_agents_md_index_at_path(
+    agents_path: &Path,
+    name: &str,
+    version: &str,
+    description: &str,
+) -> Result<()> {
+    use std::fs;
+
+    let content = if agents_path.exists() {
+        fs::read_to_string(agents_path)?
+    } else {
+        "# AGENTS.md\n\n".to_string()
+    };
+
+    // Parse existing index entries
+    let mut entries = parse_sus_index(&content);
+
+    // Add/update entry
+    let doc_name = to_doc_name(name);
+    entries.insert(
+        name.to_string(),
+        IndexEntry {
+            version: version.to_string(),
+            description: description.to_string(),
+            doc_file: format!("{}.md", doc_name),
+        },
+    );
+
+    // Generate new index section
+    let index_section = generate_index_section(&entries);
+
+    // Replace or append index in content
+    let new_content = replace_or_append_index(&content, &index_section);
+
+    fs::write(agents_path, new_content)?;
+    println!("   {} updated AGENTS.md index", "📝".cyan());
+    Ok(())
+}
+
+/// Remove a package from the AGENTS.md index
+pub fn remove_from_agents_index(package: &str) -> Result<()> {
+    remove_from_agents_index_at_path(Path::new(AGENTS_MD_PATH), package)
+}
+
+/// Internal implementation for removing from index
+pub fn remove_from_agents_index_at_path(agents_path: &Path, package: &str) -> Result<()> {
+    use std::fs;
+
+    if !agents_path.exists() {
+        return Ok(());
     }
+
+    let content = fs::read_to_string(agents_path)?;
+    let mut entries = parse_sus_index(&content);
+
+    if entries.remove(package).is_none() {
+        // Package wasn't in index
+        return Ok(());
+    }
+
+    let index_section = generate_index_section(&entries);
+    let new_content = replace_or_append_index(&content, &index_section);
+
+    fs::write(agents_path, new_content)?;
+    Ok(())
+}
+
+/// Index entry for a package
+#[derive(Debug, Clone)]
+struct IndexEntry {
+    version: String,
+    description: String,
+    doc_file: String,
+}
+
+/// Parse existing sus index from AGENTS.md content
+fn parse_sus_index(content: &str) -> HashMap<String, IndexEntry> {
+    let mut entries = HashMap::new();
+
+    // Find the index section
+    if let Some(start_idx) = content.find(SUS_INDEX_START) {
+        if let Some(end_idx) = content.find(SUS_INDEX_END) {
+            let section = &content[start_idx..end_idx];
+
+            // Parse each line in the index
+            for line in section.lines() {
+                // Format: package@version|description|doc_file.md
+                if line.contains('|') && line.contains('@') {
+                    let parts: Vec<&str> = line.split('|').collect();
+                    if parts.len() >= 3 {
+                        // Parse package@version
+                        if let Some(at_idx) = parts[0].find('@') {
+                            let name = parts[0][..at_idx].to_string();
+                            let version = parts[0][at_idx + 1..].to_string();
+                            let description = parts[1].to_string();
+                            let doc_file = parts[2].to_string();
+
+                            entries.insert(
+                                name,
+                                IndexEntry {
+                                    version,
+                                    description,
+                                    doc_file,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+/// Generate the index section content
+fn generate_index_section(entries: &HashMap<String, IndexEntry>) -> String {
+    let mut section = String::new();
+
+    section.push_str(SUS_INDEX_START);
+    section.push('\n');
+    section.push_str("## sus Package Docs\n\n");
+    section.push_str(
+        "IMPORTANT: For package usage, prefer reading .sus-docs/ over pre-training knowledge.\n\n",
+    );
+    section.push_str("[.sus-docs/]\n");
+
+    // Sort entries by name for consistent output
+    let mut sorted_entries: Vec<_> = entries.iter().collect();
+    sorted_entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (name, entry) in sorted_entries {
+        section.push_str(&format!(
+            "{}@{}|{}|{}\n",
+            name, entry.version, entry.description, entry.doc_file
+        ));
+    }
+
+    section.push_str(SUS_INDEX_END);
+    section.push('\n');
+
+    section
+}
+
+/// Replace existing index section or append new one
+fn replace_or_append_index(content: &str, index_section: &str) -> String {
+    if let Some(start_idx) = content.find(SUS_INDEX_START) {
+        if let Some(end_idx) = content.find(SUS_INDEX_END) {
+            // Replace existing section
+            let before = &content[..start_idx];
+            let after = &content[end_idx + SUS_INDEX_END.len()..];
+            return format!(
+                "{}{}{}",
+                before,
+                index_section,
+                after.trim_start_matches('\n')
+            );
+        }
+    }
+
+    // Append new section
+    let mut result = content.to_string();
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push('\n');
+    result.push_str(index_section);
+    result
 }
 
 #[cfg(test)]
@@ -389,79 +491,120 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_agents_md_creates_new_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_path = temp_dir.path().join("AGENTS.md");
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Created);
-        assert!(agents_path.exists());
-
-        let content = fs::read_to_string(&agents_path).unwrap();
-        assert!(content.contains("# AGENTS.md"));
-        assert!(content.contains(SUS_MARKER));
-        assert!(content.contains("sus add"));
+    fn test_to_doc_name() {
+        assert_eq!(to_doc_name("express"), "express");
+        assert_eq!(to_doc_name("@types/node"), "types-node");
+        assert_eq!(to_doc_name("lodash.merge"), "lodash-merge");
+        assert_eq!(to_doc_name("--test--"), "test");
+        assert_eq!(to_doc_name("Express"), "express");
+        assert_eq!(to_doc_name("@prisma/client"), "prisma-client");
     }
 
     #[test]
-    fn test_ensure_agents_md_patches_existing_file() {
+    fn test_update_agents_md_creates_new_file() {
         let temp_dir = TempDir::new().unwrap();
         let agents_path = temp_dir.path().join("AGENTS.md");
 
-        // Create existing AGENTS.md without sus section
+        update_agents_md_index_at_path(&agents_path, "express", "4.18.2", "web framework").unwrap();
+
+        assert!(agents_path.exists());
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("# AGENTS.md"));
+        assert!(content.contains(SUS_INDEX_START));
+        assert!(content.contains("express@4.18.2|web framework|express.md"));
+        assert!(content.contains(SUS_INDEX_END));
+    }
+
+    #[test]
+    fn test_update_agents_md_preserves_existing_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+
+        // Create existing AGENTS.md
         let existing_content = "# AGENTS.md\n\n## Setup\n\nRun `npm install`\n";
         fs::write(&agents_path, existing_content).unwrap();
 
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Patched);
+        update_agents_md_index_at_path(&agents_path, "lodash", "4.17.21", "utility library")
+            .unwrap();
 
         let content = fs::read_to_string(&agents_path).unwrap();
-        // Original content should still be there
         assert!(content.contains("## Setup"));
         assert!(content.contains("npm install"));
-        // Sus section should be appended
-        assert!(content.contains(SUS_MARKER));
-        assert!(content.contains("sus add"));
+        assert!(content.contains("lodash@4.17.21|utility library|lodash.md"));
     }
 
     #[test]
-    fn test_ensure_agents_md_skips_already_patched() {
+    fn test_update_agents_md_updates_existing_entry() {
         let temp_dir = TempDir::new().unwrap();
         let agents_path = temp_dir.path().join("AGENTS.md");
 
-        // Create AGENTS.md that already has sus section
-        let existing_content = format!(
-            "# AGENTS.md\n\n## Setup\n\nRun `npm install`\n\n{}",
-            SUS_AGENTS_SECTION
-        );
-        fs::write(&agents_path, &existing_content).unwrap();
+        // Add first entry
+        update_agents_md_index_at_path(&agents_path, "express", "4.18.0", "old description")
+            .unwrap();
 
-        let result = ensure_agents_md_at_path(&agents_path);
+        // Update same entry
+        update_agents_md_index_at_path(&agents_path, "express", "4.18.2", "web framework").unwrap();
 
-        assert_eq!(result, AgentsMdResult::AlreadyPatched);
-
-        // Content should be unchanged
         let content = fs::read_to_string(&agents_path).unwrap();
-        assert_eq!(content, existing_content);
+        assert!(content.contains("express@4.18.2|web framework|express.md"));
+        assert!(!content.contains("4.18.0"));
+        assert!(!content.contains("old description"));
     }
 
     #[test]
-    fn test_ensure_agents_md_handles_file_without_trailing_newline() {
+    fn test_update_agents_md_multiple_entries() {
         let temp_dir = TempDir::new().unwrap();
         let agents_path = temp_dir.path().join("AGENTS.md");
 
-        // Create existing AGENTS.md without trailing newline
-        let existing_content = "# AGENTS.md\n\n## Setup\n\nRun `npm install`";
-        fs::write(&agents_path, existing_content).unwrap();
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Patched);
+        update_agents_md_index_at_path(&agents_path, "express", "4.18.2", "web framework").unwrap();
+        update_agents_md_index_at_path(&agents_path, "lodash", "4.17.21", "utility library")
+            .unwrap();
+        update_agents_md_index_at_path(&agents_path, "@prisma/client", "5.0.0", "database ORM")
+            .unwrap();
 
         let content = fs::read_to_string(&agents_path).unwrap();
-        // Should have proper spacing between sections
-        assert!(content.contains("npm install`\n\n## sus Package Security"));
+        assert!(content.contains("express@4.18.2|web framework|express.md"));
+        assert!(content.contains("lodash@4.17.21|utility library|lodash.md"));
+        assert!(content.contains("@prisma/client@5.0.0|database ORM|prisma-client.md"));
+    }
+
+    #[test]
+    fn test_remove_from_agents_index() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+
+        // Add entries
+        update_agents_md_index_at_path(&agents_path, "express", "4.18.2", "web framework").unwrap();
+        update_agents_md_index_at_path(&agents_path, "lodash", "4.17.21", "utility library")
+            .unwrap();
+
+        // Remove one
+        remove_from_agents_index_at_path(&agents_path, "express").unwrap();
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(!content.contains("express"));
+        assert!(content.contains("lodash@4.17.21|utility library|lodash.md"));
+    }
+
+    #[test]
+    fn test_parse_sus_index() {
+        let content = r#"# AGENTS.md
+
+<!-- sus-docs-start -->
+## sus Package Docs
+
+IMPORTANT: For package usage, prefer reading .sus-docs/ over pre-training knowledge.
+
+[.sus-docs/]
+express@4.18.2|web framework|express.md
+lodash@4.17.21|utility library|lodash.md
+<!-- sus-docs-end -->
+"#;
+
+        let entries = parse_sus_index(content);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries["express"].version, "4.18.2");
+        assert_eq!(entries["express"].description, "web framework");
+        assert_eq!(entries["lodash"].version, "4.17.21");
     }
 }

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -1,8 +1,12 @@
-//! Remove command - remove packages
+//! Remove command - remove packages and clean up docs
 
+use crate::commands::add::{remove_from_agents_index, to_doc_name};
 use anyhow::Result;
 use colored::Colorize;
 use std::process::Command;
+
+/// Directory for package documentation
+const DOCS_DIR: &str = ".sus-docs";
 
 /// Run the remove command
 pub async fn run(packages: Vec<String>) -> Result<()> {
@@ -23,12 +27,20 @@ pub async fn run(packages: Vec<String>) -> Result<()> {
 
         println!("  {} removed {}", "✓".green(), package);
 
-        // Remove SKILL.md if it exists
-        let skill_path = format!(".sus/{}.skill.md", package.replace('/', "__"));
-        if std::path::Path::new(&skill_path).exists() {
-            if let Err(e) = std::fs::remove_file(&skill_path) {
-                tracing::warn!("Failed to remove {}: {}", skill_path, e);
+        // Remove doc file from .sus-docs/
+        let doc_name = to_doc_name(package);
+        let doc_path = format!("{}/{}.md", DOCS_DIR, doc_name);
+        if std::path::Path::new(&doc_path).exists() {
+            if let Err(e) = std::fs::remove_file(&doc_path) {
+                tracing::warn!("Failed to remove {}: {}", doc_path, e);
+            } else {
+                println!("   {} removed {}", "🗑️".dimmed(), doc_path);
             }
+        }
+
+        // Remove from AGENTS.md index
+        if let Err(e) = remove_from_agents_index(package) {
+            tracing::debug!("Failed to update AGENTS.md index: {}", e);
         }
     }
 

--- a/crates/worker/src/doc_generator.rs
+++ b/crates/worker/src/doc_generator.rs
@@ -1,43 +1,11 @@
-//! SKILL.md manifest generator following Agent Skills spec
-//! https://agentskills.io/specification
+//! Package documentation generator for AGENTS.md method
+//! Generates plain markdown docs instead of SKILL.md files
 
 use common::{PackageCapabilities, RiskLevel, UsageDocs};
 
-/// Convert a package name to a valid skill name
-/// - Lowercase only
-/// - Alphanumeric and hyphens only
-/// - No consecutive hyphens
-/// - Can't start or end with hyphen
-pub fn to_skill_name(package: &str) -> String {
-    let mut name: String = package
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect();
-
-    // Remove consecutive hyphens
-    while name.contains("--") {
-        name = name.replace("--", "-");
-    }
-
-    // Remove leading/trailing hyphens
-    name = name.trim_matches('-').to_string();
-
-    // Truncate to 64 chars
-    if name.len() > 64 {
-        name = name[..64].trim_end_matches('-').to_string();
-    }
-
-    // Ensure non-empty
-    if name.is_empty() {
-        name = "package".to_string();
-    }
-
-    name
-}
-
-/// Generate a SKILL.md manifest following Agent Skills spec
-pub fn generate_skill_md(
+/// Generate package documentation as plain markdown
+/// No YAML frontmatter - designed for passive context via AGENTS.md index
+pub fn generate_package_doc(
     package: &str,
     version: &str,
     caps: &PackageCapabilities,
@@ -47,37 +15,7 @@ pub fn generate_skill_md(
 ) -> String {
     let mut md = String::new();
 
-    let skill_name = to_skill_name(package);
-
-    // Build description
-    let description = usage_docs
-        .description
-        .clone()
-        .unwrap_or_else(|| format!("Usage guide for {} npm package.", package));
-
-    // Truncate description to 1024 chars max
-    let description = if description.len() > 1024 {
-        format!("{}...", &description[..1020])
-    } else {
-        description
-    };
-
-    // YAML Frontmatter (required by spec)
-    md.push_str("---\n");
-    md.push_str(&format!("name: {}\n", skill_name));
-    md.push_str(&format!(
-        "description: {} Use when working with {} in your project.\n",
-        description, package
-    ));
-    md.push_str(&format!(
-        "metadata:\n  package: {}\n  version: {}\n  generator: sus\n  generator-version: \"{}\"\n",
-        package,
-        version,
-        env!("CARGO_PKG_VERSION")
-    ));
-    md.push_str("---\n\n");
-
-    // Body content
+    // Header with package name and version
     md.push_str(&format!("# {}@{}\n\n", package, version));
 
     // Risk badge
@@ -88,6 +26,12 @@ pub fn generate_skill_md(
     };
     md.push_str(badge);
     md.push_str("\n\n");
+
+    // Description
+    if let Some(description) = &usage_docs.description {
+        md.push_str(description);
+        md.push_str("\n\n");
+    }
 
     // Quick Start
     if let Some(quick_start) = &usage_docs.quick_start {
@@ -232,23 +176,14 @@ mod tests {
     use common::{ApiDoc, NetworkCapabilities, ProcessCapabilities};
 
     #[test]
-    fn test_to_skill_name() {
-        assert_eq!(to_skill_name("express"), "express");
-        assert_eq!(to_skill_name("@types/node"), "types-node");
-        assert_eq!(to_skill_name("lodash.merge"), "lodash-merge");
-        assert_eq!(to_skill_name("--test--"), "test");
-        assert_eq!(to_skill_name("Express"), "express");
-    }
-
-    #[test]
-    fn test_generate_skill_md_has_frontmatter() {
+    fn test_generate_package_doc_no_frontmatter() {
         let caps = PackageCapabilities::default();
         let usage_docs = UsageDocs {
             description: Some("A test package".to_string()),
             ..Default::default()
         };
 
-        let md = generate_skill_md(
+        let md = generate_package_doc(
             "test-pkg",
             "1.0.0",
             &caps,
@@ -257,15 +192,18 @@ mod tests {
             &usage_docs,
         );
 
-        assert!(md.starts_with("---\n"));
-        assert!(md.contains("name: test-pkg"));
-        assert!(md.contains("description:"));
-        assert!(md.contains("metadata:"));
-        assert!(md.contains("---\n\n#"));
+        // Should NOT have YAML frontmatter
+        assert!(!md.starts_with("---\n"));
+        assert!(!md.contains("name: test-pkg"));
+        assert!(!md.contains("metadata:"));
+
+        // Should start with header
+        assert!(md.starts_with("# test-pkg@1.0.0\n"));
+        assert!(md.contains("A test package"));
     }
 
     #[test]
-    fn test_generate_skill_md_with_usage_docs() {
+    fn test_generate_package_doc_with_usage_docs() {
         let caps = PackageCapabilities {
             network: NetworkCapabilities {
                 makes_requests: true,
@@ -292,7 +230,7 @@ mod tests {
             gotchas: vec!["Don't forget to close connections".to_string()],
         };
 
-        let md = generate_skill_md(
+        let md = generate_package_doc(
             "test-pkg",
             "1.0.0",
             &caps,
@@ -301,7 +239,6 @@ mod tests {
             &usage_docs,
         );
 
-        assert!(md.contains("name: test-pkg"));
         assert!(md.contains("# test-pkg@1.0.0"));
         assert!(md.contains("A test package for testing"));
         assert!(md.contains("## Quick Start"));
@@ -315,5 +252,7 @@ mod tests {
         assert!(md.contains("warning-yellow"));
         assert!(md.contains("api.example.com"));
         assert!(md.contains("process: true"));
+        assert!(md.contains("## Risk Assessment"));
+        assert!(md.contains("Test warning"));
     }
 }

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -1,7 +1,7 @@
 //! sus Scan Worker - processes package scan jobs from the queue
 
+mod doc_generator;
 mod scanner;
-mod skill_generator;
 
 use anyhow::Result;
 use axum::{routing::get, Json, Router};

--- a/crates/worker/src/scanner/mod.rs
+++ b/crates/worker/src/scanner/mod.rs
@@ -5,7 +5,7 @@ mod capabilities;
 mod cve;
 mod npm;
 
-use crate::skill_generator::generate_skill_md;
+use crate::doc_generator::generate_package_doc;
 use anyhow::Result;
 use capabilities::CapabilityExtractor;
 use chrono::{DateTime, Utc};
@@ -148,7 +148,8 @@ pub struct ScanResult {
     pub cves: Vec<CveSummary>,
     pub agentic_threats: Vec<AgenticThreatSummary>,
     pub capabilities: PackageCapabilities,
-    pub skill_md: String,
+    /// Package documentation (stored as skill_md in database for backward compatibility)
+    pub package_doc: String,
 }
 
 /// Main package scanner
@@ -306,8 +307,8 @@ impl PackageScanner {
         let (risk_level, risk_reasons) =
             calculate_risk(&cves, &agentic_threats, &capabilities, trust_score);
 
-        // 7. Generate SKILL.md
-        let skill_md = generate_skill_md(
+        // 7. Generate package documentation
+        let package_doc = generate_package_doc(
             package,
             version,
             &capabilities,
@@ -347,7 +348,7 @@ impl PackageScanner {
                 maintainers: maintainers_ref.map(|m| serde_json::to_value(m).unwrap_or_default()),
                 last_publish,
                 capabilities: serde_json::to_value(&capabilities)?,
-                skill_md: Some(skill_md.clone()),
+                skill_md: Some(package_doc.clone()),
                 scan_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             })
             .await?;
@@ -392,7 +393,7 @@ impl PackageScanner {
             cves,
             agentic_threats,
             capabilities,
-            skill_md,
+            package_doc,
         })
     }
 }


### PR DESCRIPTION
## Summary

Switches from skills to AGENTS.md docs index. [Vercel ran evals](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) and found AGENTS.md hit 100% pass rate. Skills hit 53%, same as having no docs at all.

## Why

### 1. Agents ignored skills more than half the time

Skills require the agent to decide "I should look this up." In Vercel's tests, agents didn't make that decision in 56% of cases. The skill existed, the agent could use it, and it just... didn't.

| Config | Pass Rate |
|--------|-----------|
| No docs | 53% |
| Skills | 53% |
| Skills + explicit instructions | 79% |
| AGENTS.md index | 100% |

Zero improvement over baseline.

### 2. Forcing skill usage was fragile

Adding instructions like "invoke the skill before coding" got skills up to 79%. But small wording changes broke things. "You MUST invoke the skill" made agents miss project context. "Explore first, then invoke" worked better.

Same skill, same docs, different results depending on how you phrase the instruction.

### 3. AGENTS.md removes the decision

Docs are in context on every turn. The agent doesn't decide whether to look something up. It's already there. No decision point means no failure to decide.

## What changed

Before: SKILL.md files in 7 agent folders

After: Plain markdown in `.sus-docs/`, index in AGENTS.md

## Test plan

- [ ] `sus add express` creates `.sus-docs/express.md` and updates AGENTS.md
- [ ] `sus remove express` cleans up both