### PR TITLE
feat: improve package search relevance ranking

### DIFF
--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -342,6 +342,7 @@ impl Database {
     }
 
     /// Search packages by name with pagination and CVE/threat counts
+    /// Results are ranked by relevance: exact match > starts with > contains
     pub async fn search_packages(
         &self,
         query: &str,
@@ -359,11 +360,19 @@ impl Database {
                 COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
             FROM packages p
             WHERE p.name ILIKE $1
-            ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
-            LIMIT $2 OFFSET $3
+            ORDER BY 
+                CASE 
+                    WHEN LOWER(p.name) = LOWER($2) THEN 0
+                    WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
+                    ELSE 2
+                END,
+                p.weekly_downloads DESC NULLS LAST,
+                p.name ASC
+            LIMIT $3 OFFSET $4
             "#,
         )
         .bind(&pattern)
+        .bind(query)
         .bind(limit)
         .bind(offset)
         .fetch_all(&self.pool)


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

Search results now prioritize exact matches over partial matches:
1. Exact match (e.g., "ai" when searching "ai")
2. Starts with query (e.g., "ai-sdk")
3. Contains query (e.g., "openai")

Within each tier, results are still sorted by weekly downloads.

## Why

<!-- Why is this needed? -->

Improve search UX

## Test plan

- [x] Tests pass locally
- [x] Tested manually
