### PR TITLE
feat: sus init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["sus contributors"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ curl -fsSL https://sus-pm.com/install.sh | sh
 
 ## usage
 
+### initialize sus
+
+```bash
+sus init
+```
+
+configures sus for your project. optionally enables AGENTS.md docs index for AI coding agents.
+
 ### add packages (with safety checks)
 
 ```bash
@@ -112,6 +120,7 @@ sus check lodash
 ### other commands
 
 ```bash
+sus init             # initialize sus in project
 sus add <pkg>        # install with safety checks
 sus remove <pkg>     # uninstall
 sus scan             # audit current project
@@ -147,11 +156,16 @@ sus scan --json               # machine-readable output
 
 ---
 
-## agent skills
+## AGENTS.md docs index
 
-sus automatically generates [Agent Skills](https://agentskills.io) for each installed package. skills are saved to your existing coding agent folders (`.cursor/skills/`, `.claude/skills/`, `.windsurf/skills/`, etc.) following the [Agent Skills specification](https://agentskills.io/specification).
+sus can generate a compressed docs index in your `AGENTS.md` file, following [Vercel's research](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) showing that passive context outperforms active skill retrieval (100% vs 79% pass rate in their evals).
 
-each skill includes quick start examples, best practices, gotchas, and capability requirements — so your ai agent can use packages correctly without guessing.
+run `sus init` to enable this feature. when enabled:
+- package documentation is saved to `.sus-docs/`
+- `AGENTS.md` is updated with a compressed index pointing to these docs
+- your AI agent gets version-matched documentation without needing to invoke skills
+
+this approach ensures your agent uses retrieval-led reasoning over potentially outdated training data.
 
 ---
 
@@ -181,7 +195,7 @@ each skill includes quick start examples, best practices, gotchas, and capabilit
 │    → GET api.sus-pm.com/v1/packages/express │
 │    → get pre-computed risk assessment       │
 │    → install if safe                        │
-│    → generate agent skills                  │
+│    → update AGENTS.md docs index            │
 └─────────────────────────────────────────────┘
 ```
 
@@ -210,7 +224,7 @@ if you're building an agent that installs packages, sus is for you.
 | malware detection | ❌ | ❌ | ❌ | ✅ |
 | typosquat detection | ❌ | ❌ | ❌ | ✅ |
 | prompt injection detection | ❌ | ❌ | ❌ | ✅ |
-| generates agent skills | ❌ | ❌ | ❌ | ✅ |
+| AGENTS.md docs index | ❌ | ❌ | ❌ | ✅ |
 | built for ai agents | ❌ | ❌ | ❌ | ✅ |
 
 ---

--- a/crates/cli/src/agents_md.rs
+++ b/crates/cli/src/agents_md.rs
@@ -1,0 +1,433 @@
+//! AGENTS.md docs index management
+//!
+//! Manages the compressed docs index in AGENTS.md following Vercel's approach:
+//! https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+const AGENTS_MD_PATH: &str = "AGENTS.md";
+const SUS_DOCS_DIR: &str = ".sus-docs";
+
+/// Marker to detect sus section in AGENTS.md
+const SUS_MARKER_START: &str = "[sus Docs Index]";
+const SUS_MARKER_END: &str = "[/sus Docs Index]";
+
+/// Convert a package name to a valid filename
+/// - Lowercase only
+/// - Alphanumeric and hyphens only
+/// - No consecutive hyphens
+/// - Can't start or end with hyphen
+pub fn to_doc_filename(package: &str) -> String {
+    let mut name: String = package
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Remove consecutive hyphens
+    while name.contains("--") {
+        name = name.replace("--", "-");
+    }
+
+    // Remove leading/trailing hyphens
+    name = name.trim_matches('-').to_string();
+
+    // Truncate to 64 chars
+    if name.len() > 64 {
+        name = name[..64].trim_end_matches('-').to_string();
+    }
+
+    // Ensure non-empty
+    if name.is_empty() {
+        name = "package".to_string();
+    }
+
+    format!("{}.md", name)
+}
+
+/// Save package documentation to .sus-docs/
+pub fn save_doc(package: &str, content: &str) -> Result<()> {
+    save_doc_at_path(package, content, Path::new(SUS_DOCS_DIR))
+}
+
+fn save_doc_at_path(package: &str, content: &str, docs_dir: &Path) -> Result<()> {
+    // Create .sus-docs directory if it doesn't exist
+    fs::create_dir_all(docs_dir)?;
+
+    let filename = to_doc_filename(package);
+    let doc_path = docs_dir.join(&filename);
+    fs::write(&doc_path, content)?;
+
+    Ok(())
+}
+
+/// Remove package documentation from .sus-docs/
+pub fn remove_doc(package: &str) -> Result<bool> {
+    remove_doc_at_path(package, Path::new(SUS_DOCS_DIR))
+}
+
+fn remove_doc_at_path(package: &str, docs_dir: &Path) -> Result<bool> {
+    let filename = to_doc_filename(package);
+    let doc_path = docs_dir.join(&filename);
+
+    if doc_path.exists() {
+        fs::remove_file(&doc_path)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Update AGENTS.md with current .sus-docs index
+pub fn update_agents_md_index() -> Result<()> {
+    update_agents_md_index_at_path(Path::new(AGENTS_MD_PATH), Path::new(SUS_DOCS_DIR))
+}
+
+fn update_agents_md_index_at_path(agents_path: &Path, docs_dir: &Path) -> Result<()> {
+    let index = generate_index(docs_dir)?;
+
+    if agents_path.exists() {
+        // Read existing content
+        let content = fs::read_to_string(agents_path)?;
+
+        // Check if sus section exists
+        if content.contains(SUS_MARKER_START) {
+            // Replace existing sus section
+            let new_content = replace_sus_section(&content, &index);
+            fs::write(agents_path, new_content)?;
+        } else {
+            // Append sus section
+            let new_content = if content.ends_with('\n') {
+                format!("{}\n{}", content, index)
+            } else {
+                format!("{}\n\n{}", content, index)
+            };
+            fs::write(agents_path, new_content)?;
+        }
+    } else {
+        // Create new AGENTS.md with sus section
+        let content = format!("# AGENTS.md\n\n{}", index);
+        fs::write(agents_path, content)?;
+    }
+
+    Ok(())
+}
+
+/// Remove sus section from AGENTS.md
+#[allow(dead_code)]
+pub fn remove_agents_md_index() -> Result<()> {
+    remove_agents_md_index_at_path(Path::new(AGENTS_MD_PATH))
+}
+
+fn remove_agents_md_index_at_path(agents_path: &Path) -> Result<()> {
+    if !agents_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(agents_path)?;
+
+    if !content.contains(SUS_MARKER_START) {
+        return Ok(());
+    }
+
+    let new_content = remove_sus_section(&content);
+
+    // If only the sus section was there, remove the file
+    let trimmed = new_content.trim();
+    if trimmed.is_empty() || trimmed == "# AGENTS.md" {
+        fs::remove_file(agents_path)?;
+    } else {
+        fs::write(agents_path, new_content)?;
+    }
+
+    Ok(())
+}
+
+/// Generate compressed index from .sus-docs/ contents
+fn generate_index(docs_dir: &Path) -> Result<String> {
+    let mut packages: Vec<String> = Vec::new();
+
+    if docs_dir.exists() {
+        for entry in fs::read_dir(docs_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(filename) = path.file_name() {
+                    if let Some(name) = filename.to_str() {
+                        if name.ends_with(".md") {
+                            packages.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort for deterministic output
+    packages.sort();
+
+    let packages_list = if packages.is_empty() {
+        String::new()
+    } else {
+        packages.join(",")
+    };
+
+    // Build compressed index following Vercel's format
+    let mut index = String::new();
+    index.push_str(SUS_MARKER_START);
+    index.push_str("|root: ./");
+    index.push_str(SUS_DOCS_DIR);
+    index.push('\n');
+    index.push_str("|IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning\n");
+
+    if !packages_list.is_empty() {
+        index.push_str(&format!("|packages:{{{}}}\n", packages_list));
+    }
+
+    index.push_str(SUS_MARKER_END);
+    index.push('\n');
+
+    Ok(index)
+}
+
+/// Replace existing sus section with new index
+fn replace_sus_section(content: &str, new_index: &str) -> String {
+    let start_idx = content.find(SUS_MARKER_START);
+    let end_idx = content.find(SUS_MARKER_END);
+
+    match (start_idx, end_idx) {
+        (Some(start), Some(end)) => {
+            let end_of_marker = end + SUS_MARKER_END.len();
+            // Skip any trailing newline after end marker
+            let end_of_section = if content[end_of_marker..].starts_with('\n') {
+                end_of_marker + 1
+            } else {
+                end_of_marker
+            };
+
+            let before = &content[..start];
+            let after = &content[end_of_section..];
+
+            // Handle spacing
+            let before_trimmed = before.trim_end_matches('\n');
+            let after_trimmed = after.trim_start_matches('\n');
+
+            if before_trimmed.is_empty() && after_trimmed.is_empty() {
+                new_index.to_string()
+            } else if before_trimmed.is_empty() {
+                format!("{}\n{}", new_index, after_trimmed)
+            } else if after_trimmed.is_empty() {
+                format!("{}\n\n{}", before_trimmed, new_index)
+            } else {
+                format!("{}\n\n{}\n{}", before_trimmed, new_index, after_trimmed)
+            }
+        }
+        _ => {
+            // Marker not properly closed, append new index
+            if content.ends_with('\n') {
+                format!("{}\n{}", content, new_index)
+            } else {
+                format!("{}\n\n{}", content, new_index)
+            }
+        }
+    }
+}
+
+/// Remove sus section from content
+fn remove_sus_section(content: &str) -> String {
+    let start_idx = content.find(SUS_MARKER_START);
+    let end_idx = content.find(SUS_MARKER_END);
+
+    match (start_idx, end_idx) {
+        (Some(start), Some(end)) => {
+            let end_of_marker = end + SUS_MARKER_END.len();
+            // Skip any trailing newlines after end marker
+            let end_of_section = if content[end_of_marker..].starts_with('\n') {
+                end_of_marker + 1
+            } else {
+                end_of_marker
+            };
+
+            let before = &content[..start];
+            let after = &content[end_of_section..];
+
+            // Clean up extra newlines
+            let before_trimmed = before.trim_end_matches('\n');
+            let after_trimmed = after.trim_start_matches('\n');
+
+            if before_trimmed.is_empty() && after_trimmed.is_empty() {
+                String::new()
+            } else if before_trimmed.is_empty() {
+                after_trimmed.to_string()
+            } else if after_trimmed.is_empty() {
+                format!("{}\n", before_trimmed)
+            } else {
+                format!("{}\n\n{}", before_trimmed, after_trimmed)
+            }
+        }
+        _ => content.to_string(),
+    }
+}
+
+/// Ensure .sus-docs directory exists
+pub fn ensure_docs_dir() -> Result<()> {
+    fs::create_dir_all(SUS_DOCS_DIR)?;
+    Ok(())
+}
+
+/// List all packages in .sus-docs/
+#[allow(dead_code)]
+pub fn list_docs() -> Result<Vec<String>> {
+    list_docs_at_path(Path::new(SUS_DOCS_DIR))
+}
+
+fn list_docs_at_path(docs_dir: &Path) -> Result<Vec<String>> {
+    let mut packages = Vec::new();
+
+    if !docs_dir.exists() {
+        return Ok(packages);
+    }
+
+    for entry in fs::read_dir(docs_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(filename) = path.file_name() {
+                if let Some(name) = filename.to_str() {
+                    if let Some(stripped) = name.strip_suffix(".md") {
+                        packages.push(stripped.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    packages.sort();
+    Ok(packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_to_doc_filename() {
+        assert_eq!(to_doc_filename("express"), "express.md");
+        assert_eq!(to_doc_filename("@types/node"), "types-node.md");
+        assert_eq!(to_doc_filename("lodash.merge"), "lodash-merge.md");
+        assert_eq!(to_doc_filename("--test--"), "test.md");
+        assert_eq!(to_doc_filename("Express"), "express.md");
+    }
+
+    #[test]
+    fn test_save_and_remove_doc() {
+        let temp_dir = TempDir::new().unwrap();
+        let docs_dir = temp_dir.path().join(".sus-docs");
+
+        save_doc_at_path("express", "# Express docs", &docs_dir).unwrap();
+        assert!(docs_dir.join("express.md").exists());
+
+        let removed = remove_doc_at_path("express", &docs_dir).unwrap();
+        assert!(removed);
+        assert!(!docs_dir.join("express.md").exists());
+    }
+
+    #[test]
+    fn test_generate_index_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let docs_dir = temp_dir.path().join(".sus-docs");
+
+        let index = generate_index(&docs_dir).unwrap();
+        assert!(index.contains("[sus Docs Index]"));
+        assert!(index.contains("retrieval-led reasoning"));
+        assert!(!index.contains("packages:"));
+    }
+
+    #[test]
+    fn test_generate_index_with_packages() {
+        let temp_dir = TempDir::new().unwrap();
+        let docs_dir = temp_dir.path().join(".sus-docs");
+        fs::create_dir_all(&docs_dir).unwrap();
+
+        fs::write(docs_dir.join("express.md"), "# Express").unwrap();
+        fs::write(docs_dir.join("lodash.md"), "# Lodash").unwrap();
+
+        let index = generate_index(&docs_dir).unwrap();
+        assert!(index.contains("[sus Docs Index]"));
+        assert!(index.contains("packages:{express.md,lodash.md}"));
+    }
+
+    #[test]
+    fn test_update_agents_md_creates_new() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+        let docs_dir = temp_dir.path().join(".sus-docs");
+        fs::create_dir_all(&docs_dir).unwrap();
+        fs::write(docs_dir.join("express.md"), "# Express").unwrap();
+
+        update_agents_md_index_at_path(&agents_path, &docs_dir).unwrap();
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("# AGENTS.md"));
+        assert!(content.contains("[sus Docs Index]"));
+        assert!(content.contains("express.md"));
+    }
+
+    #[test]
+    fn test_update_agents_md_appends() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+        let docs_dir = temp_dir.path().join(".sus-docs");
+        fs::create_dir_all(&docs_dir).unwrap();
+
+        // Create existing AGENTS.md
+        fs::write(&agents_path, "# AGENTS.md\n\n## Setup\n\nRun npm install\n").unwrap();
+
+        update_agents_md_index_at_path(&agents_path, &docs_dir).unwrap();
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("## Setup"));
+        assert!(content.contains("[sus Docs Index]"));
+    }
+
+    #[test]
+    fn test_update_agents_md_replaces() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+        let docs_dir = temp_dir.path().join(".sus-docs");
+        fs::create_dir_all(&docs_dir).unwrap();
+
+        // Create existing AGENTS.md with sus section
+        let existing = "# AGENTS.md\n\n[sus Docs Index]|root: ./.sus-docs\n|packages:{old.md}\n[/sus Docs Index]\n";
+        fs::write(&agents_path, existing).unwrap();
+
+        // Add new package
+        fs::write(docs_dir.join("express.md"), "# Express").unwrap();
+
+        update_agents_md_index_at_path(&agents_path, &docs_dir).unwrap();
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("express.md"));
+        assert!(!content.contains("old.md"));
+    }
+
+    #[test]
+    fn test_remove_agents_md_index() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_path = temp_dir.path().join("AGENTS.md");
+
+        // Create AGENTS.md with sus section and other content
+        let content = "# AGENTS.md\n\n## Setup\n\n[sus Docs Index]|root: ./.sus-docs\n[/sus Docs Index]\n\n## Other\n";
+        fs::write(&agents_path, content).unwrap();
+
+        remove_agents_md_index_at_path(&agents_path).unwrap();
+
+        let new_content = fs::read_to_string(&agents_path).unwrap();
+        assert!(!new_content.contains("[sus Docs Index]"));
+        assert!(new_content.contains("## Setup"));
+        assert!(new_content.contains("## Other"));
+    }
+}

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -1,6 +1,8 @@
 //! Add command - install packages with safety checks
 
+use crate::agents_md;
 use crate::api_client::SusClient;
+use crate::config;
 use crate::ui::{self, print_capabilities, print_risk};
 use anyhow::Result;
 use colored::Colorize;
@@ -35,8 +37,8 @@ pub async fn run(
     yolo: bool,
     strict: bool,
 ) -> Result<()> {
-    // Ensure AGENTS.md exists with sus instructions (only runs once)
-    ensure_agents_md();
+    // Check if AGENTS.md docs feature is enabled
+    let agents_md_enabled = config::is_agents_md_enabled();
 
     for package_spec in &packages {
         let (name, version) = parse_package_spec(package_spec);
@@ -152,9 +154,11 @@ pub async fn run(
         install_package(package_spec).await?;
         println!("{}", "📦 installed".green());
 
-        // Save agent skills to all coding agent folders
-        if let Some(skill_md) = &assessment.skill_md {
-            save_agent_skills(name, skill_md);
+        // Save docs and update AGENTS.md index if enabled
+        if agents_md_enabled {
+            if let Some(skill_md) = &assessment.skill_md {
+                save_package_docs(name, skill_md);
+            }
         }
     }
 
@@ -195,184 +199,31 @@ fn detect_package_manager() -> String {
     "npm".to_string()
 }
 
-/// Coding agent root folders
-const AGENT_ROOTS: &[&str] = &[
-    ".agents",
-    ".claude",
-    ".codex",
-    ".cursor",
-    ".gemini",
-    ".opencode",
-    ".windsurf",
-];
-
-/// AGENTS.md file path
-const AGENTS_MD_PATH: &str = "AGENTS.md";
-
-/// Marker to detect if AGENTS.md has already been patched with sus instructions
-const SUS_MARKER: &str = "## sus Package Security";
-
-/// Content to add to AGENTS.md
-const SUS_AGENTS_SECTION: &str = r#"## sus Package Security
-
-When installing packages in this project, use `sus` instead of directly using package managers (npm, pip, cargo, etc.):
-
-- Install packages: `sus add <package-name>`
-- Check a package: `sus check <package-name>`
-
-sus performs security analysis before installation. After installing a package, check the skills folder in your agent's directory (e.g., `.cursor/skills/`, `.claude/skills/`) for package-specific usage guidance.
-"#;
-
-/// Ensure AGENTS.md exists and contains sus instructions
-/// Creates the file if it doesn't exist, or patches it if the sus section is missing
-fn ensure_agents_md() {
-    ensure_agents_md_at_path(std::path::Path::new(AGENTS_MD_PATH));
-}
-
-/// Result of ensuring AGENTS.md
-#[derive(Debug, PartialEq)]
-enum AgentsMdResult {
-    /// File was created
-    Created,
-    /// File was patched (sus section added)
-    Patched,
-    /// File already had sus section
-    AlreadyPatched,
-    /// Error occurred
-    Error,
-}
-
-/// Internal implementation that accepts a path for testability
-fn ensure_agents_md_at_path(agents_path: &std::path::Path) -> AgentsMdResult {
-    use std::fs;
-
-    // Check if file exists
-    if agents_path.exists() {
-        // Read existing content
-        match fs::read_to_string(agents_path) {
-            Ok(content) => {
-                // Check if already patched
-                if content.contains(SUS_MARKER) {
-                    // Already patched, nothing to do
-                    return AgentsMdResult::AlreadyPatched;
-                }
-
-                // Append sus section to existing file
-                let new_content = if content.ends_with('\n') {
-                    format!("{}\n{}", content, SUS_AGENTS_SECTION)
-                } else {
-                    format!("{}\n\n{}", content, SUS_AGENTS_SECTION)
-                };
-
-                if let Err(e) = fs::write(agents_path, new_content) {
-                    tracing::warn!("Failed to patch AGENTS.md: {}", e);
-                    AgentsMdResult::Error
-                } else {
-                    println!(
-                        "   {} patched {} with sus instructions",
-                        "📝".cyan(),
-                        agents_path.display()
-                    );
-                    AgentsMdResult::Patched
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Failed to read AGENTS.md: {}", e);
-                AgentsMdResult::Error
-            }
-        }
-    } else {
-        // Create new AGENTS.md with sus section
-        let content = format!("# AGENTS.md\n\n{}", SUS_AGENTS_SECTION);
-
-        if let Err(e) = fs::write(agents_path, content) {
-            tracing::warn!("Failed to create AGENTS.md: {}", e);
-            AgentsMdResult::Error
-        } else {
-            println!(
-                "   {} created {} with sus instructions",
-                "📝".cyan(),
-                agents_path.display()
-            );
-            AgentsMdResult::Created
-        }
-    }
-}
-
-/// Convert package name to valid skill name (per Agent Skills spec)
-fn to_skill_name(package: &str) -> String {
-    let mut name: String = package
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect();
-
-    // Remove consecutive hyphens
-    while name.contains("--") {
-        name = name.replace("--", "-");
+/// Save package documentation to .sus-docs/ and update AGENTS.md index
+fn save_package_docs(package_name: &str, doc_content: &str) {
+    // Save doc to .sus-docs/
+    if let Err(e) = agents_md::save_doc(package_name, doc_content) {
+        tracing::warn!("Failed to save package doc: {}", e);
+        return;
     }
 
-    // Remove leading/trailing hyphens
-    name = name.trim_matches('-').to_string();
-
-    // Truncate to 64 chars
-    if name.len() > 64 {
-        name = name[..64].trim_end_matches('-').to_string();
+    // Update AGENTS.md index
+    if let Err(e) = agents_md::update_agents_md_index() {
+        tracing::warn!("Failed to update AGENTS.md index: {}", e);
+        return;
     }
 
-    if name.is_empty() {
-        "package".to_string()
-    } else {
-        name
-    }
-}
-
-/// Save agent skill to existing coding agent folders only
-/// Follows Agent Skills spec: {agent}/skills/{skill-name}/SKILL.md
-fn save_agent_skills(package_name: &str, skill_content: &str) {
-    use std::path::Path;
-
-    let skill_name = to_skill_name(package_name);
-    let mut saved_count = 0;
-
-    for agent_root in AGENT_ROOTS {
-        // Only write to agent folders that already exist
-        if !Path::new(agent_root).exists() {
-            continue;
-        }
-
-        let skills_dir = format!("{}/skills", agent_root);
-        let skill_dir = format!("{}/{}", skills_dir, skill_name);
-        let skill_path = format!("{}/SKILL.md", skill_dir);
-
-        // Create the skill directory structure
-        if let Err(e) = std::fs::create_dir_all(&skill_dir) {
-            tracing::debug!("Failed to create {}: {}", skill_dir, e);
-            continue;
-        }
-
-        if let Err(e) = std::fs::write(&skill_path, skill_content) {
-            tracing::debug!("Failed to write {}: {}", skill_path, e);
-        } else {
-            saved_count += 1;
-        }
-    }
-
-    if saved_count > 0 {
-        println!(
-            "   {} saved skill to {} agent folder{}",
-            "📚".cyan(),
-            saved_count,
-            if saved_count == 1 { "" } else { "s" }
-        );
-    }
+    println!(
+        "   {} saved docs to {} and updated {}",
+        "📚".cyan(),
+        ".sus-docs/".cyan(),
+        "AGENTS.md".cyan()
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
 
     #[test]
     fn test_parse_package_spec() {
@@ -386,82 +237,5 @@ mod tests {
             parse_package_spec("@types/node@18.0.0"),
             ("@types/node", Some("18.0.0"))
         );
-    }
-
-    #[test]
-    fn test_ensure_agents_md_creates_new_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_path = temp_dir.path().join("AGENTS.md");
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Created);
-        assert!(agents_path.exists());
-
-        let content = fs::read_to_string(&agents_path).unwrap();
-        assert!(content.contains("# AGENTS.md"));
-        assert!(content.contains(SUS_MARKER));
-        assert!(content.contains("sus add"));
-    }
-
-    #[test]
-    fn test_ensure_agents_md_patches_existing_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_path = temp_dir.path().join("AGENTS.md");
-
-        // Create existing AGENTS.md without sus section
-        let existing_content = "# AGENTS.md\n\n## Setup\n\nRun `npm install`\n";
-        fs::write(&agents_path, existing_content).unwrap();
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Patched);
-
-        let content = fs::read_to_string(&agents_path).unwrap();
-        // Original content should still be there
-        assert!(content.contains("## Setup"));
-        assert!(content.contains("npm install"));
-        // Sus section should be appended
-        assert!(content.contains(SUS_MARKER));
-        assert!(content.contains("sus add"));
-    }
-
-    #[test]
-    fn test_ensure_agents_md_skips_already_patched() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_path = temp_dir.path().join("AGENTS.md");
-
-        // Create AGENTS.md that already has sus section
-        let existing_content = format!(
-            "# AGENTS.md\n\n## Setup\n\nRun `npm install`\n\n{}",
-            SUS_AGENTS_SECTION
-        );
-        fs::write(&agents_path, &existing_content).unwrap();
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::AlreadyPatched);
-
-        // Content should be unchanged
-        let content = fs::read_to_string(&agents_path).unwrap();
-        assert_eq!(content, existing_content);
-    }
-
-    #[test]
-    fn test_ensure_agents_md_handles_file_without_trailing_newline() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_path = temp_dir.path().join("AGENTS.md");
-
-        // Create existing AGENTS.md without trailing newline
-        let existing_content = "# AGENTS.md\n\n## Setup\n\nRun `npm install`";
-        fs::write(&agents_path, existing_content).unwrap();
-
-        let result = ensure_agents_md_at_path(&agents_path);
-
-        assert_eq!(result, AgentsMdResult::Patched);
-
-        let content = fs::read_to_string(&agents_path).unwrap();
-        // Should have proper spacing between sections
-        assert!(content.contains("npm install`\n\n## sus Package Security"));
     }
 }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,0 +1,81 @@
+//! Init command - initialize sus in a project
+
+use crate::agents_md;
+use crate::config::{save_config, SusConfig};
+use anyhow::Result;
+use colored::Colorize;
+use dialoguer::Confirm;
+use std::path::Path;
+
+const CONFIG_FILE: &str = "sus.json";
+
+/// Run the init command
+pub async fn run(yes: bool) -> Result<()> {
+    println!();
+    println!("  {} initializing sus...", "🔧".cyan());
+    println!();
+
+    // Check if already initialized
+    if Path::new(CONFIG_FILE).exists() {
+        println!(
+            "  {} sus.json already exists. Reinitializing...",
+            "ℹ️".blue()
+        );
+        println!();
+    }
+
+    // Ask about AGENTS.md docs index (skip if --yes flag is passed)
+    let agents_md_enabled = if yes {
+        true
+    } else {
+        Confirm::new()
+            .with_prompt("  Enable AGENTS.md docs index for AI coding agents?")
+            .default(true)
+            .interact()?
+    };
+
+    // Create config
+    let config = SusConfig {
+        agents_md: agents_md_enabled,
+    };
+
+    // Save config
+    save_config(&config)?;
+    println!();
+    println!("  {} created sus.json", "✓".green());
+
+    if agents_md_enabled {
+        // Create .sus-docs directory
+        agents_md::ensure_docs_dir()?;
+        println!("  {} created .sus-docs/", "✓".green());
+
+        // Create/update AGENTS.md with initial index
+        agents_md::update_agents_md_index()?;
+        println!("  {} updated AGENTS.md with sus docs index", "✓".green());
+
+        println!();
+        println!(
+            "  {} AGENTS.md docs index enabled. When you run {},",
+            "📚".cyan(),
+            "sus add <package>".cyan()
+        );
+        println!(
+            "     package documentation will be saved to {} and indexed in {}.",
+            ".sus-docs/".cyan(),
+            "AGENTS.md".cyan()
+        );
+    } else {
+        println!();
+        println!(
+            "  {} AGENTS.md docs index disabled. You can enable it later by running {}.",
+            "ℹ️".blue(),
+            "sus init".cyan()
+        );
+    }
+
+    println!();
+    println!("  {} sus initialized successfully!", "✓".green());
+    println!();
+
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod add;
 pub mod check;
+pub mod init;
 pub mod remove;
 pub mod scan;
 pub mod update;

--- a/crates/cli/src/commands/remove.rs
+++ b/crates/cli/src/commands/remove.rs
@@ -1,11 +1,16 @@
 //! Remove command - remove packages
 
+use crate::agents_md;
+use crate::config;
 use anyhow::Result;
 use colored::Colorize;
 use std::process::Command;
 
 /// Run the remove command
 pub async fn run(packages: Vec<String>) -> Result<()> {
+    // Check if AGENTS.md docs feature is enabled
+    let agents_md_enabled = config::is_agents_md_enabled();
+
     for package in &packages {
         println!("📦 removing {}...", package.cyan());
 
@@ -23,12 +28,9 @@ pub async fn run(packages: Vec<String>) -> Result<()> {
 
         println!("  {} removed {}", "✓".green(), package);
 
-        // Remove SKILL.md if it exists
-        let skill_path = format!(".sus/{}.skill.md", package.replace('/', "__"));
-        if std::path::Path::new(&skill_path).exists() {
-            if let Err(e) = std::fs::remove_file(&skill_path) {
-                tracing::warn!("Failed to remove {}: {}", skill_path, e);
-            }
+        // Remove docs from .sus-docs/ and update AGENTS.md index if enabled
+        if agents_md_enabled {
+            remove_package_docs(package);
         }
     }
 
@@ -47,4 +49,30 @@ fn detect_package_manager() -> String {
         return "bun".to_string();
     }
     "npm".to_string()
+}
+
+/// Remove package documentation from .sus-docs/ and update AGENTS.md index
+fn remove_package_docs(package_name: &str) {
+    // Remove doc from .sus-docs/
+    match agents_md::remove_doc(package_name) {
+        Ok(true) => {
+            // Update AGENTS.md index
+            if let Err(e) = agents_md::update_agents_md_index() {
+                tracing::warn!("Failed to update AGENTS.md index: {}", e);
+                return;
+            }
+            println!(
+                "  {} removed docs from {} and updated {}",
+                "📚".cyan(),
+                ".sus-docs/".cyan(),
+                "AGENTS.md".cyan()
+            );
+        }
+        Ok(false) => {
+            // Doc didn't exist, nothing to do
+        }
+        Err(e) => {
+            tracing::warn!("Failed to remove package doc: {}", e);
+        }
+    }
 }

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,0 +1,120 @@
+//! Configuration management for sus.json
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const CONFIG_FILE: &str = "sus.json";
+
+/// sus project configuration
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SusConfig {
+    /// Whether to generate AGENTS.md docs index
+    #[serde(default)]
+    pub agents_md: bool,
+}
+
+/// Load configuration from sus.json in current directory
+/// Returns None if file doesn't exist, errors on parse failures
+pub fn load_config() -> Option<SusConfig> {
+    load_config_from_path(Path::new(CONFIG_FILE))
+}
+
+/// Internal implementation for testability
+fn load_config_from_path(path: &Path) -> Option<SusConfig> {
+    if !path.exists() {
+        return None;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(content) => match serde_json::from_str(&content) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                tracing::warn!("Failed to parse sus.json: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!("Failed to read sus.json: {}", e);
+            None
+        }
+    }
+}
+
+/// Save configuration to sus.json in current directory
+pub fn save_config(config: &SusConfig) -> Result<()> {
+    save_config_to_path(config, Path::new(CONFIG_FILE))
+}
+
+/// Internal implementation for testability
+fn save_config_to_path(config: &SusConfig, path: &Path) -> Result<()> {
+    let content = serde_json::to_string_pretty(config)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+/// Check if AGENTS.md docs feature is enabled
+pub fn is_agents_md_enabled() -> bool {
+    load_config().map(|c| c.agents_md).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_config_missing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sus.json");
+
+        let config = load_config_from_path(&config_path);
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_save_and_load_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sus.json");
+
+        let config = SusConfig { agents_md: true };
+        save_config_to_path(&config, &config_path).unwrap();
+
+        let loaded = load_config_from_path(&config_path).unwrap();
+        assert!(loaded.agents_md);
+    }
+
+    #[test]
+    fn test_load_config_with_agents_md_false() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sus.json");
+
+        std::fs::write(&config_path, r#"{"agents_md": false}"#).unwrap();
+
+        let loaded = load_config_from_path(&config_path).unwrap();
+        assert!(!loaded.agents_md);
+    }
+
+    #[test]
+    fn test_load_config_defaults() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sus.json");
+
+        // Empty JSON object should use defaults
+        std::fs::write(&config_path, r#"{}"#).unwrap();
+
+        let loaded = load_config_from_path(&config_path).unwrap();
+        assert!(!loaded.agents_md); // default is false
+    }
+
+    #[test]
+    fn test_load_config_invalid_json() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sus.json");
+
+        std::fs::write(&config_path, "not valid json").unwrap();
+
+        let config = load_config_from_path(&config_path);
+        assert!(config.is_none());
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,7 +1,9 @@
 //! sus CLI - Security-first package gateway for AI agents
 
+mod agents_md;
 mod api_client;
 mod commands;
+mod config;
 mod ui;
 
 use clap::{Parser, Subcommand};
@@ -29,6 +31,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Initialize sus in the current project
+    Init {
+        /// Skip prompts and use defaults (enables AGENTS.md docs)
+        #[arg(long, short)]
+        yes: bool,
+    },
+
     /// Add packages (with safety checks)
     Add {
         /// Packages to install (e.g., "lodash", "express@4.18.0")
@@ -93,6 +102,8 @@ async fn main() -> anyhow::Result<()> {
     let client = api_client::SusClient::new(&cli.api_url);
 
     match cli.command {
+        Commands::Init { yes } => commands::init::run(yes).await,
+
         Commands::Add {
             packages,
             yolo,


### PR DESCRIPTION
## What

Add `sus init` command and replace per-agent-folder skills with AGENTS.md docs index.

- New `sus init` command to initialize project settings (stored in `sus.json`)
- Package docs saved to `.sus-docs/` with compressed index in `AGENTS.md`
- Search API now ranks results by relevance (exact → starts with → contains)

## Why

[Vercel's research](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) showed passive context in AGENTS.md outperforms active skill retrieval (100% vs 79% pass rate). This replaces writing to multiple agent folders (`.cursor/skills/`, `.claude/skills/`, etc.) with a single compressed index that agents can read directly.

## Test plan

- [x] Tests pass locally
- [x] Tested manually
  - `sus init --yes` creates `sus.json`, `.sus-docs/`, and `AGENTS.md`
  - `sus add openai` saves docs and updates index
  - `sus remove openai` removes docs and updates index
  - With `agents_md: false`, no docs are created/removed