### PR TITLE
feat: add PyPI registry support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ url = { version = "2.5", features = ["serde"] }
 semver = { version = "1.0", features = ["serde"] }
 flate2 = "1.0"
 tar = "0.4"
+zip = "2.2"
 tempfile = "3.14"
 dotenvy = "0.15"
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["sus contributors"]
 license = "MIT"

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 # Stage 1: Chef setup
-FROM rust:1.85-alpine AS chef
+FROM rust:1.88-alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile.cve
+++ b/Dockerfile.cve
@@ -1,5 +1,5 @@
 # Stage 1: Chef setup
-FROM rust:1.85-alpine AS chef
+FROM rust:1.88-alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -1,5 +1,5 @@
 # Stage 1: Chef setup
-FROM rust:1.85-alpine AS chef
+FROM rust:1.88-alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Stage 1: Chef setup
-FROM rust:1.85-alpine AS chef
+FROM rust:1.88-alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ if you're building an agent that installs packages, sus is for you.
 ## roadmap
 
 - [x] npm support
-- [ ] pypi support
+- [x] pypi support
 - [ ] crates.io support
 - [ ] go modules support
 - [ ] private registry support

--- a/crates/cli/src/api_client.rs
+++ b/crates/cli/src/api_client.rs
@@ -2,7 +2,8 @@
 
 use anyhow::{Context, Result};
 use common::{
-    BulkLookupRequest, PackageResponse, PackageVersionPair, ScanRequest, ScanRequestResponse,
+    BulkLookupRequest, PackageResponse, PackageVersionPair, Registry, ScanRequest,
+    ScanRequestResponse,
 };
 use reqwest::Client;
 
@@ -70,18 +71,28 @@ impl SusClient {
             .context("Failed to parse API response")
     }
 
-    /// Request a scan for a package
+    /// Request a scan for a package (defaults to npm registry)
     pub async fn request_scan(
         &self,
         name: &str,
         version: Option<&str>,
+    ) -> Result<ScanRequestResponse> {
+        self.request_scan_with_registry(name, version, None).await
+    }
+
+    /// Request a scan for a package with a specific registry
+    pub async fn request_scan_with_registry(
+        &self,
+        name: &str,
+        version: Option<&str>,
+        registry: Option<Registry>,
     ) -> Result<ScanRequestResponse> {
         let url = format!("{}/v1/scan", self.base_url);
 
         let request = ScanRequest {
             name: name.to_string(),
             version: version.map(String::from),
-            registry: None, // Default to npm
+            registry,
         };
 
         let response = self

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -3,32 +3,13 @@
 use crate::agents_md;
 use crate::api_client::SusClient;
 use crate::config;
+use crate::project::{self, NpmPackageManager, ProjectType, PypiPackageManager};
 use crate::ui::{self, print_capabilities, print_risk};
 use anyhow::Result;
 use colored::Colorize;
 use common::RiskLevel;
 use dialoguer::Confirm;
 use std::process::Command;
-
-/// Parse a package string into name and optional version
-fn parse_package_spec(spec: &str) -> (&str, Option<&str>) {
-    // Handle scoped packages like @types/node@1.0.0
-    if let Some(rest) = spec.strip_prefix('@') {
-        // Find the second @ for version
-        if let Some(idx) = rest.find('@') {
-            let idx = idx + 1; // Adjust for the @ prefix
-            return (&spec[..idx], Some(&spec[idx + 1..]));
-        }
-        return (spec, None);
-    }
-
-    // Regular package like lodash@4.17.0
-    if let Some(idx) = spec.find('@') {
-        return (&spec[..idx], Some(&spec[idx + 1..]));
-    }
-
-    (spec, None)
-}
 
 /// Run the add command
 pub async fn run(
@@ -37,24 +18,37 @@ pub async fn run(
     yolo: bool,
     strict: bool,
 ) -> Result<()> {
+    // Detect project type
+    let project_type = match project::detect_project_type() {
+        Some(pt) => pt,
+        None => {
+            anyhow::bail!(
+                "No supported project files found.\n\
+                 Supported files:\n\
+                 - npm: package.json, pnpm-lock.yaml, yarn.lock, bun.lockb\n\
+                 - python: requirements.txt, pyproject.toml, Pipfile, setup.py"
+            );
+        }
+    };
+
     // Check if AGENTS.md docs feature is enabled
     let agents_md_enabled = config::is_agents_md_enabled();
 
     for package_spec in &packages {
-        let (name, version) = parse_package_spec(package_spec);
-        let display_name = if let Some(v) = version {
-            format!("{}@{}", name, v)
+        let (name, version) = project::parse_package_spec(package_spec, &project_type);
+        let display_name = if let Some(ref v) = version {
+            format_display_name(&name, v, &project_type)
         } else {
-            name.to_string()
+            name.clone()
         };
 
         let pb = ui::spinner(&format!("checking {}...", display_name));
 
         // Fetch assessment from API
-        let assessment = match if let Some(v) = version {
-            client.get_package_version(name, v).await
+        let assessment = match if let Some(ref v) = version {
+            client.get_package_version(&name, v).await
         } else {
-            client.get_package(name).await
+            client.get_package(&name).await
         } {
             Ok(a) => {
                 ui::finish_spinner(&pb, a.risk_level.emoji(), &display_name);
@@ -68,7 +62,11 @@ pub async fn run(
                         display_name.yellow()
                     );
 
-                    match client.request_scan(name, version).await {
+                    let registry = project_type.registry();
+                    match client
+                        .request_scan_with_registry(&name, version.as_deref(), Some(registry))
+                        .await
+                    {
                         Ok(resp) => {
                             println!(
                                 "  scan queued (job {}), try again in ~{}s",
@@ -92,7 +90,7 @@ pub async fn run(
                     }
 
                     // If yolo, proceed without assessment
-                    install_package(package_spec).await?;
+                    install_package(package_spec, &project_type)?;
                     continue;
                 } else {
                     ui::finish_spinner(&pb, "❌", &display_name);
@@ -151,13 +149,13 @@ pub async fn run(
         }
 
         // Install the package
-        install_package(package_spec).await?;
+        install_package(package_spec, &project_type)?;
         println!("{}", "📦 installed".green());
 
         // Save docs and update AGENTS.md index if enabled
         if agents_md_enabled {
             if let Some(skill_md) = &assessment.skill_md {
-                save_package_docs(name, skill_md);
+                save_package_docs(&name, skill_md);
             }
         }
     }
@@ -165,38 +163,64 @@ pub async fn run(
     Ok(())
 }
 
-/// Install a package using npm/pnpm/yarn
-async fn install_package(package: &str) -> Result<()> {
-    // Detect package manager
-    let pm = detect_package_manager();
+/// Format display name based on project type
+fn format_display_name(name: &str, version: &str, project_type: &ProjectType) -> String {
+    match project_type {
+        ProjectType::Npm(_) => format!("{}@{}", name, version),
+        ProjectType::Pypi(_) => format!("{}=={}", name, version),
+    }
+}
 
-    let status = Command::new(&pm)
-        .args(["add", package])
+/// Install a package using the appropriate package manager
+fn install_package(package: &str, project_type: &ProjectType) -> Result<()> {
+    match project_type {
+        ProjectType::Npm(pm) => install_npm_package(package, *pm),
+        ProjectType::Pypi(pm) => install_pypi_package(package, *pm),
+    }
+}
+
+/// Install an npm package
+fn install_npm_package(package: &str, pm: NpmPackageManager) -> Result<()> {
+    let cmd = pm.command();
+    let install_cmd = pm.install_cmd();
+
+    let status = Command::new(cmd)
+        .args([install_cmd, package])
         .status()
-        .map_err(|e| anyhow::anyhow!("Failed to run {}: {}", pm, e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to run {}: {}", cmd, e))?;
 
     if !status.success() {
-        anyhow::bail!("{} add failed with exit code {:?}", pm, status.code());
+        anyhow::bail!(
+            "{} {} failed with exit code {:?}",
+            cmd,
+            install_cmd,
+            status.code()
+        );
     }
 
     Ok(())
 }
 
-/// Detect which package manager to use
-fn detect_package_manager() -> String {
-    // Check for lockfiles in order of preference
-    if std::path::Path::new("pnpm-lock.yaml").exists() {
-        return "pnpm".to_string();
-    }
-    if std::path::Path::new("yarn.lock").exists() {
-        return "yarn".to_string();
-    }
-    if std::path::Path::new("bun.lockb").exists() {
-        return "bun".to_string();
+/// Install a PyPI package
+fn install_pypi_package(package: &str, pm: PypiPackageManager) -> Result<()> {
+    let cmd = pm.command();
+    let install_cmd = pm.install_cmd();
+
+    let status = Command::new(cmd)
+        .args([install_cmd, package])
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to run {}: {}", cmd, e))?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "{} {} failed with exit code {:?}",
+            cmd,
+            install_cmd,
+            status.code()
+        );
     }
 
-    // Default to npm
-    "npm".to_string()
+    Ok(())
 }
 
 /// Save package documentation to .sus-docs/ and update AGENTS.md index
@@ -226,16 +250,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_package_spec() {
-        assert_eq!(parse_package_spec("lodash"), ("lodash", None));
+    fn test_format_display_name() {
+        let npm = ProjectType::Npm(NpmPackageManager::Npm);
+        let pypi = ProjectType::Pypi(PypiPackageManager::Pip);
+
         assert_eq!(
-            parse_package_spec("lodash@4.17.0"),
-            ("lodash", Some("4.17.0"))
+            format_display_name("lodash", "4.17.0", &npm),
+            "lodash@4.17.0"
         );
-        assert_eq!(parse_package_spec("@types/node"), ("@types/node", None));
         assert_eq!(
-            parse_package_spec("@types/node@18.0.0"),
-            ("@types/node", Some("18.0.0"))
+            format_display_name("requests", "2.31.0", &pypi),
+            "requests==2.31.0"
         );
     }
 }

--- a/crates/cli/src/commands/scan.rs
+++ b/crates/cli/src/commands/scan.rs
@@ -4,21 +4,44 @@ use crate::api_client::SusClient;
 use crate::ui::{self, print_scan_summary};
 use anyhow::Result;
 use colored::Colorize;
-use common::{PackageResponse, PackageVersionPair, RiskLevel};
+use common::{PackageResponse, PackageVersionPair, Registry, RiskLevel};
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Detected project type
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ProjectType {
+    Npm,
+    Python,
+}
+
 /// Run the scan command
 pub async fn run(client: &SusClient, json: bool) -> Result<()> {
-    // Find package.json
-    if !Path::new("package.json").exists() {
-        anyhow::bail!("No package.json found in current directory");
-    }
+    // Detect project type
+    let project_type = detect_project_type();
 
-    // Parse dependencies
-    let pb = ui::spinner("reading dependencies...");
-    let deps = get_all_dependencies()?;
-    ui::finish_spinner(&pb, "📦", &format!("found {} packages", deps.len()));
+    let (deps, project_name) = match project_type {
+        Some(ProjectType::Npm) => {
+            let pb = ui::spinner("reading npm dependencies...");
+            let deps = get_npm_dependencies()?;
+            ui::finish_spinner(&pb, "📦", &format!("found {} npm packages", deps.len()));
+            (deps, "npm")
+        }
+        Some(ProjectType::Python) => {
+            let pb = ui::spinner("reading python dependencies...");
+            let deps = get_python_dependencies()?;
+            ui::finish_spinner(&pb, "🐍", &format!("found {} python packages", deps.len()));
+            (deps, "python")
+        }
+        None => {
+            anyhow::bail!(
+                "No supported project files found.\n\
+                 Supported files:\n\
+                 - npm: package.json\n\
+                 - python: requirements.txt, pyproject.toml"
+            );
+        }
+    };
 
     if deps.is_empty() {
         println!("  no dependencies found");
@@ -27,7 +50,7 @@ pub async fn run(client: &SusClient, json: bool) -> Result<()> {
 
     if !json {
         println!();
-        println!("🔍 scanning {} packages...", deps.len());
+        println!("🔍 scanning {} {} packages...", deps.len(), project_name);
         println!();
     }
 
@@ -70,6 +93,7 @@ pub async fn run(client: &SusClient, json: bool) -> Result<()> {
     if json {
         let output = serde_json::json!({
             "total": deps.len(),
+            "project_type": project_name,
             "clean": clean.len(),
             "warnings": warnings.len(),
             "critical": critical.len(),
@@ -129,8 +153,27 @@ pub async fn run(client: &SusClient, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Parse package.json and package-lock.json to get all dependencies
-fn get_all_dependencies() -> Result<Vec<PackageVersionPair>> {
+/// Detect the project type based on files present
+fn detect_project_type() -> Option<ProjectType> {
+    // Check for npm first
+    if Path::new("package.json").exists() {
+        return Some(ProjectType::Npm);
+    }
+
+    // Check for Python
+    if Path::new("requirements.txt").exists()
+        || Path::new("pyproject.toml").exists()
+        || Path::new("setup.py").exists()
+        || Path::new("Pipfile").exists()
+    {
+        return Some(ProjectType::Python);
+    }
+
+    None
+}
+
+/// Parse package.json and package-lock.json to get all npm dependencies
+fn get_npm_dependencies() -> Result<Vec<PackageVersionPair>> {
     let mut deps = Vec::new();
 
     // Read package.json
@@ -144,7 +187,7 @@ fn get_all_dependencies() -> Result<Vec<PackageVersionPair>> {
                 deps.push(PackageVersionPair {
                     name: name.clone(),
                     version: clean_version(v),
-                    registry: None,
+                    registry: Some(Registry::Npm),
                 });
             }
         }
@@ -157,7 +200,7 @@ fn get_all_dependencies() -> Result<Vec<PackageVersionPair>> {
                 deps.push(PackageVersionPair {
                     name: name.clone(),
                     version: clean_version(v),
-                    registry: None,
+                    registry: Some(Registry::Npm),
                 });
             }
         }
@@ -181,7 +224,7 @@ fn get_all_dependencies() -> Result<Vec<PackageVersionPair>> {
                             deps.push(PackageVersionPair {
                                 name: name.to_string(),
                                 version: version.to_string(),
-                                registry: None,
+                                registry: Some(Registry::Npm),
                             });
                         }
                     }
@@ -204,6 +247,289 @@ fn get_all_dependencies() -> Result<Vec<PackageVersionPair>> {
     Ok(deps)
 }
 
+/// Parse Python dependency files to get all dependencies
+fn get_python_dependencies() -> Result<Vec<PackageVersionPair>> {
+    let mut deps = Vec::new();
+
+    // Try requirements.txt first (most common)
+    if Path::new("requirements.txt").exists() {
+        let content = std::fs::read_to_string("requirements.txt")?;
+        parse_requirements_txt(&content, &mut deps);
+    }
+
+    // Try pyproject.toml
+    if Path::new("pyproject.toml").exists() {
+        let content = std::fs::read_to_string("pyproject.toml")?;
+        parse_pyproject_toml(&content, &mut deps);
+    }
+
+    // Try Pipfile (Pipenv)
+    if Path::new("Pipfile").exists() {
+        let content = std::fs::read_to_string("Pipfile")?;
+        parse_pipfile(&content, &mut deps);
+    }
+
+    // Try Pipfile.lock for exact versions
+    if Path::new("Pipfile.lock").exists() {
+        if let Ok(content) = std::fs::read_to_string("Pipfile.lock") {
+            parse_pipfile_lock(&content, &mut deps);
+        }
+    }
+
+    // Deduplicate (keep the one with a version if there are duplicates)
+    deps.sort_by(|a, b| {
+        let name_cmp = a.name.to_lowercase().cmp(&b.name.to_lowercase());
+        if name_cmp == std::cmp::Ordering::Equal {
+            // Prefer non-empty versions
+            b.version.len().cmp(&a.version.len())
+        } else {
+            name_cmp
+        }
+    });
+    deps.dedup_by(|a, b| a.name.to_lowercase() == b.name.to_lowercase());
+
+    Ok(deps)
+}
+
+/// Parse requirements.txt format
+fn parse_requirements_txt(content: &str, deps: &mut Vec<PackageVersionPair>) {
+    for line in content.lines() {
+        let line = line.trim();
+
+        // Skip comments and empty lines
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Skip -r, -e, --extra-index-url, etc.
+        if line.starts_with('-') {
+            continue;
+        }
+
+        // Parse package==version, package>=version, package~=version, etc.
+        if let Some((name, version)) = parse_python_requirement(line) {
+            deps.push(PackageVersionPair {
+                name,
+                version,
+                registry: Some(Registry::Pypi),
+            });
+        }
+    }
+}
+
+/// Parse a single Python requirement line
+fn parse_python_requirement(line: &str) -> Option<(String, String)> {
+    // Remove environment markers (everything after ;)
+    let line = line.split(';').next()?.trim();
+
+    // Remove extras (e.g., package[extra1,extra2])
+    let line = if let Some(bracket_pos) = line.find('[') {
+        if let Some(bracket_end) = line.find(']') {
+            format!("{}{}", &line[..bracket_pos], &line[bracket_end + 1..])
+        } else {
+            line.to_string()
+        }
+    } else {
+        line.to_string()
+    };
+
+    // Try different version specifiers
+    let specifiers = ["===", "==", "~=", "!=", ">=", "<=", ">", "<"];
+
+    for spec in specifiers {
+        if let Some(pos) = line.find(spec) {
+            let name = line[..pos].trim().to_string();
+            let version_part = line[pos + spec.len()..].trim();
+
+            // Handle version ranges like >=1.0,<2.0
+            let version = version_part
+                .split(',')
+                .next()
+                .unwrap_or(version_part)
+                .trim()
+                .to_string();
+
+            if !name.is_empty() {
+                return Some((name, version));
+            }
+        }
+    }
+
+    // No version specified - just package name
+    let name = line.trim().to_string();
+    if !name.is_empty() && !name.contains(' ') {
+        return Some((name, "latest".to_string()));
+    }
+
+    None
+}
+
+/// Parse pyproject.toml for dependencies
+fn parse_pyproject_toml(content: &str, deps: &mut Vec<PackageVersionPair>) {
+    // Simple line-by-line parsing for dependencies
+    let mut in_dependencies = false;
+    let mut in_optional_deps = false;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        // Check for dependencies section
+        if line == "[project.dependencies]" || line.starts_with("dependencies = [") {
+            in_dependencies = true;
+            continue;
+        }
+
+        if line.starts_with("[project.optional-dependencies") {
+            in_optional_deps = true;
+            continue;
+        }
+
+        // End of section
+        if line.starts_with('[') && !line.contains("dependencies") {
+            in_dependencies = false;
+            in_optional_deps = false;
+            continue;
+        }
+
+        // Parse inline dependencies array
+        if line.starts_with("dependencies = [") {
+            // Handle single-line: dependencies = ["pkg1", "pkg2"]
+            if let Some(start) = line.find('[') {
+                let deps_str = &line[start + 1..];
+                if let Some(end) = deps_str.find(']') {
+                    parse_toml_deps_array(&deps_str[..end], deps);
+                }
+            }
+            continue;
+        }
+
+        // Parse dependencies in multi-line array
+        if in_dependencies || in_optional_deps {
+            // Handle closing bracket
+            if line == "]" || line == "]," {
+                in_dependencies = false;
+                in_optional_deps = false;
+                continue;
+            }
+
+            // Parse quoted dependency
+            let line = line.trim_matches(',');
+            if let Some(dep) = extract_quoted_string(line) {
+                if let Some((name, version)) = parse_python_requirement(&dep) {
+                    deps.push(PackageVersionPair {
+                        name,
+                        version,
+                        registry: Some(Registry::Pypi),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Parse TOML dependencies array content (between [ and ])
+fn parse_toml_deps_array(content: &str, deps: &mut Vec<PackageVersionPair>) {
+    // Split by comma and parse each
+    for part in content.split(',') {
+        if let Some(dep) = extract_quoted_string(part.trim()) {
+            if let Some((name, version)) = parse_python_requirement(&dep) {
+                deps.push(PackageVersionPair {
+                    name,
+                    version,
+                    registry: Some(Registry::Pypi),
+                });
+            }
+        }
+    }
+}
+
+/// Extract string content from quotes
+fn extract_quoted_string(s: &str) -> Option<String> {
+    let s = s.trim();
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        Some(s[1..s.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+/// Parse Pipfile for dependencies
+fn parse_pipfile(content: &str, deps: &mut Vec<PackageVersionPair>) {
+    let mut in_packages = false;
+    let mut in_dev_packages = false;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if line == "[packages]" {
+            in_packages = true;
+            in_dev_packages = false;
+            continue;
+        }
+
+        if line == "[dev-packages]" {
+            in_packages = false;
+            in_dev_packages = true;
+            continue;
+        }
+
+        if line.starts_with('[') {
+            in_packages = false;
+            in_dev_packages = false;
+            continue;
+        }
+
+        if in_packages || in_dev_packages {
+            // Parse: package = "version" or package = "*"
+            if let Some(eq_pos) = line.find('=') {
+                let name = line[..eq_pos].trim().to_string();
+                let version_part = line[eq_pos + 1..].trim();
+
+                // Remove quotes
+                let version = version_part
+                    .trim_matches('"')
+                    .trim_matches('\'')
+                    .to_string();
+
+                if !name.is_empty() {
+                    let version = if version == "*" {
+                        "latest".to_string()
+                    } else {
+                        version
+                    };
+
+                    deps.push(PackageVersionPair {
+                        name,
+                        version,
+                        registry: Some(Registry::Pypi),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Parse Pipfile.lock for exact versions
+fn parse_pipfile_lock(content: &str, deps: &mut Vec<PackageVersionPair>) {
+    if let Ok(lock_json) = serde_json::from_str::<serde_json::Value>(content) {
+        for section in ["default", "develop"] {
+            if let Some(packages) = lock_json.get(section).and_then(|p| p.as_object()) {
+                for (name, info) in packages {
+                    if let Some(version) = info.get("version").and_then(|v| v.as_str()) {
+                        // Version in Pipfile.lock starts with ==
+                        let version = version.trim_start_matches("==").to_string();
+                        deps.push(PackageVersionPair {
+                            name: name.clone(),
+                            version,
+                            registry: Some(Registry::Pypi),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Recursively collect dependencies from package-lock v1/v2 format
 fn collect_lock_deps(
     deps: &serde_json::Map<String, serde_json::Value>,
@@ -214,7 +540,7 @@ fn collect_lock_deps(
             out.push(PackageVersionPair {
                 name: name.clone(),
                 version: version.to_string(),
-                registry: None,
+                registry: Some(Registry::Npm),
             });
         }
         // Recurse into nested dependencies

--- a/crates/cli/src/commands/scan.rs
+++ b/crates/cli/src/commands/scan.rs
@@ -1,6 +1,7 @@
 //! Scan command - scan current project for vulnerabilities
 
 use crate::api_client::SusClient;
+use crate::project::{self, ProjectType};
 use crate::ui::{self, print_scan_summary};
 use anyhow::Result;
 use colored::Colorize;
@@ -8,26 +9,19 @@ use common::{PackageResponse, PackageVersionPair, Registry, RiskLevel};
 use std::collections::HashMap;
 use std::path::Path;
 
-/// Detected project type
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum ProjectType {
-    Npm,
-    Python,
-}
-
 /// Run the scan command
 pub async fn run(client: &SusClient, json: bool) -> Result<()> {
-    // Detect project type
-    let project_type = detect_project_type();
+    // Detect project type using shared module
+    let project_type = project::detect_project_type();
 
     let (deps, project_name) = match project_type {
-        Some(ProjectType::Npm) => {
+        Some(ProjectType::Npm(_)) => {
             let pb = ui::spinner("reading npm dependencies...");
             let deps = get_npm_dependencies()?;
             ui::finish_spinner(&pb, "📦", &format!("found {} npm packages", deps.len()));
             (deps, "npm")
         }
-        Some(ProjectType::Python) => {
+        Some(ProjectType::Pypi(_)) => {
             let pb = ui::spinner("reading python dependencies...");
             let deps = get_python_dependencies()?;
             ui::finish_spinner(&pb, "🐍", &format!("found {} python packages", deps.len()));
@@ -37,8 +31,8 @@ pub async fn run(client: &SusClient, json: bool) -> Result<()> {
             anyhow::bail!(
                 "No supported project files found.\n\
                  Supported files:\n\
-                 - npm: package.json\n\
-                 - python: requirements.txt, pyproject.toml"
+                 - npm: package.json, pnpm-lock.yaml, yarn.lock, bun.lockb\n\
+                 - python: requirements.txt, pyproject.toml, Pipfile, setup.py"
             );
         }
     };
@@ -151,25 +145,6 @@ pub async fn run(client: &SusClient, json: bool) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Detect the project type based on files present
-fn detect_project_type() -> Option<ProjectType> {
-    // Check for npm first
-    if Path::new("package.json").exists() {
-        return Some(ProjectType::Npm);
-    }
-
-    // Check for Python
-    if Path::new("requirements.txt").exists()
-        || Path::new("pyproject.toml").exists()
-        || Path::new("setup.py").exists()
-        || Path::new("Pipfile").exists()
-    {
-        return Some(ProjectType::Python);
-    }
-
-    None
 }
 
 /// Parse package.json and package-lock.json to get all npm dependencies

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@ mod agents_md;
 mod api_client;
 mod commands;
 mod config;
+mod project;
 mod ui;
 
 use clap::{Parser, Subcommand};

--- a/crates/cli/src/project.rs
+++ b/crates/cli/src/project.rs
@@ -1,0 +1,278 @@
+//! Project type detection for multi-registry support
+
+use common::Registry;
+use std::path::Path;
+
+/// Detected project type with associated package manager
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProjectType {
+    Npm(NpmPackageManager),
+    Pypi(PypiPackageManager),
+}
+
+impl ProjectType {
+    /// Get the registry for this project type
+    pub fn registry(&self) -> Registry {
+        match self {
+            ProjectType::Npm(_) => Registry::Npm,
+            ProjectType::Pypi(_) => Registry::Pypi,
+        }
+    }
+}
+
+/// npm ecosystem package managers
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NpmPackageManager {
+    Npm,
+    Yarn,
+    Pnpm,
+    Bun,
+}
+
+impl NpmPackageManager {
+    /// Get the command name for this package manager
+    pub fn command(&self) -> &'static str {
+        match self {
+            NpmPackageManager::Npm => "npm",
+            NpmPackageManager::Yarn => "yarn",
+            NpmPackageManager::Pnpm => "pnpm",
+            NpmPackageManager::Bun => "bun",
+        }
+    }
+
+    /// Get the install subcommand for this package manager
+    pub fn install_cmd(&self) -> &'static str {
+        "add"
+    }
+}
+
+/// Python ecosystem package managers
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PypiPackageManager {
+    Pip,
+    Poetry,
+    Pipenv,
+    Uv,
+}
+
+impl PypiPackageManager {
+    /// Get the command name for this package manager
+    pub fn command(&self) -> &'static str {
+        match self {
+            PypiPackageManager::Pip => "pip",
+            PypiPackageManager::Poetry => "poetry",
+            PypiPackageManager::Pipenv => "pipenv",
+            PypiPackageManager::Uv => "uv",
+        }
+    }
+
+    /// Get the install subcommand for this package manager
+    pub fn install_cmd(&self) -> &'static str {
+        match self {
+            PypiPackageManager::Pip => "install",
+            PypiPackageManager::Poetry => "add",
+            PypiPackageManager::Pipenv => "install",
+            PypiPackageManager::Uv => "add",
+        }
+    }
+}
+
+/// Detect the project type based on files in the current directory
+///
+/// Detection priority:
+/// 1. Python lockfiles (most specific): poetry.lock, Pipfile.lock, uv.lock
+/// 2. Python project files: pyproject.toml, requirements.txt, Pipfile, setup.py
+/// 3. npm lockfiles: pnpm-lock.yaml, yarn.lock, bun.lockb
+/// 4. npm project files: package.json
+pub fn detect_project_type() -> Option<ProjectType> {
+    // Check Python lockfiles first (most specific)
+    if Path::new("poetry.lock").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Poetry));
+    }
+    if Path::new("Pipfile.lock").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Pipenv));
+    }
+    if Path::new("uv.lock").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Uv));
+    }
+
+    // Check Python project files
+    if Path::new("pyproject.toml").exists() {
+        // Check if it's a poetry project
+        if let Ok(content) = std::fs::read_to_string("pyproject.toml") {
+            if content.contains("[tool.poetry]") {
+                return Some(ProjectType::Pypi(PypiPackageManager::Poetry));
+            }
+            if content.contains("[tool.uv]") {
+                return Some(ProjectType::Pypi(PypiPackageManager::Uv));
+            }
+        }
+        // Default to pip for pyproject.toml
+        return Some(ProjectType::Pypi(PypiPackageManager::Pip));
+    }
+    if Path::new("requirements.txt").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Pip));
+    }
+    if Path::new("Pipfile").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Pipenv));
+    }
+    if Path::new("setup.py").exists() {
+        return Some(ProjectType::Pypi(PypiPackageManager::Pip));
+    }
+
+    // Check npm lockfiles
+    if Path::new("pnpm-lock.yaml").exists() {
+        return Some(ProjectType::Npm(NpmPackageManager::Pnpm));
+    }
+    if Path::new("yarn.lock").exists() {
+        return Some(ProjectType::Npm(NpmPackageManager::Yarn));
+    }
+    if Path::new("bun.lockb").exists() {
+        return Some(ProjectType::Npm(NpmPackageManager::Bun));
+    }
+
+    // Check npm project file
+    if Path::new("package.json").exists() {
+        return Some(ProjectType::Npm(NpmPackageManager::Npm));
+    }
+
+    None
+}
+
+/// Parse a package specification into name and optional version
+///
+/// Handles both npm-style (@) and PyPI-style (==, >=, etc.) version specifiers
+pub fn parse_package_spec(spec: &str, project_type: &ProjectType) -> (String, Option<String>) {
+    match project_type {
+        ProjectType::Npm(_) => parse_npm_package_spec(spec),
+        ProjectType::Pypi(_) => parse_pypi_package_spec(spec),
+    }
+}
+
+/// Parse npm package specification (e.g., "lodash@4.17.0", "@types/node@18.0.0")
+fn parse_npm_package_spec(spec: &str) -> (String, Option<String>) {
+    // Handle scoped packages like @types/node@1.0.0
+    if let Some(rest) = spec.strip_prefix('@') {
+        // Find the second @ for version
+        if let Some(idx) = rest.find('@') {
+            let idx = idx + 1; // Adjust for the @ prefix
+            return (spec[..idx].to_string(), Some(spec[idx + 1..].to_string()));
+        }
+        return (spec.to_string(), None);
+    }
+
+    // Regular package like lodash@4.17.0
+    if let Some(idx) = spec.find('@') {
+        return (spec[..idx].to_string(), Some(spec[idx + 1..].to_string()));
+    }
+
+    (spec.to_string(), None)
+}
+
+/// Parse PyPI package specification (e.g., "requests==2.31.0", "flask>=2.0")
+fn parse_pypi_package_spec(spec: &str) -> (String, Option<String>) {
+    // Check for version specifiers in order of specificity
+    let version_ops = ["===", "==", "!=", "~=", ">=", "<=", ">", "<"];
+
+    for op in version_ops {
+        if let Some(idx) = spec.find(op) {
+            let name = spec[..idx].to_string();
+            let version = spec[idx + op.len()..].to_string();
+            return (name, Some(version));
+        }
+    }
+
+    // Check for bracket extras like requests[security]
+    if let Some(idx) = spec.find('[') {
+        let name = spec[..idx].to_string();
+        return (name, None);
+    }
+
+    (spec.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_npm_package_spec() {
+        let npm = ProjectType::Npm(NpmPackageManager::Npm);
+
+        assert_eq!(
+            parse_package_spec("lodash", &npm),
+            ("lodash".to_string(), None)
+        );
+        assert_eq!(
+            parse_package_spec("lodash@4.17.0", &npm),
+            ("lodash".to_string(), Some("4.17.0".to_string()))
+        );
+        assert_eq!(
+            parse_package_spec("@types/node", &npm),
+            ("@types/node".to_string(), None)
+        );
+        assert_eq!(
+            parse_package_spec("@types/node@18.0.0", &npm),
+            ("@types/node".to_string(), Some("18.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_pypi_package_spec() {
+        let pypi = ProjectType::Pypi(PypiPackageManager::Pip);
+
+        assert_eq!(
+            parse_package_spec("requests", &pypi),
+            ("requests".to_string(), None)
+        );
+        assert_eq!(
+            parse_package_spec("requests==2.31.0", &pypi),
+            ("requests".to_string(), Some("2.31.0".to_string()))
+        );
+        assert_eq!(
+            parse_package_spec("flask>=2.0", &pypi),
+            ("flask".to_string(), Some("2.0".to_string()))
+        );
+        assert_eq!(
+            parse_package_spec("django~=4.2", &pypi),
+            ("django".to_string(), Some("4.2".to_string()))
+        );
+        assert_eq!(
+            parse_package_spec("requests[security]", &pypi),
+            ("requests".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn test_project_type_registry() {
+        assert_eq!(
+            ProjectType::Npm(NpmPackageManager::Npm).registry(),
+            Registry::Npm
+        );
+        assert_eq!(
+            ProjectType::Pypi(PypiPackageManager::Pip).registry(),
+            Registry::Pypi
+        );
+    }
+
+    #[test]
+    fn test_package_manager_commands() {
+        assert_eq!(NpmPackageManager::Npm.command(), "npm");
+        assert_eq!(NpmPackageManager::Yarn.command(), "yarn");
+        assert_eq!(NpmPackageManager::Pnpm.command(), "pnpm");
+        assert_eq!(NpmPackageManager::Bun.command(), "bun");
+
+        assert_eq!(PypiPackageManager::Pip.command(), "pip");
+        assert_eq!(PypiPackageManager::Poetry.command(), "poetry");
+        assert_eq!(PypiPackageManager::Pipenv.command(), "pipenv");
+        assert_eq!(PypiPackageManager::Uv.command(), "uv");
+    }
+
+    #[test]
+    fn test_install_commands() {
+        assert_eq!(NpmPackageManager::Npm.install_cmd(), "add");
+        assert_eq!(PypiPackageManager::Pip.install_cmd(), "install");
+        assert_eq!(PypiPackageManager::Poetry.install_cmd(), "add");
+        assert_eq!(PypiPackageManager::Uv.install_cmd(), "add");
+    }
+}

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -494,6 +494,105 @@ pub struct NpmDist {
     pub integrity: Option<String>,
 }
 
+// =============================================================================
+// PyPI-specific types
+// =============================================================================
+
+/// PyPI package metadata from registry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PypiPackageMetadata {
+    pub name: String,
+    pub version: String,
+    pub summary: Option<String>,
+    pub author: Option<String>,
+    pub author_email: Option<String>,
+    pub maintainer: Option<String>,
+    pub maintainer_email: Option<String>,
+    pub home_page: Option<String>,
+    pub project_url: Option<String>,
+    pub project_urls: Option<HashMap<String, String>>,
+    pub license: Option<String>,
+    pub requires_python: Option<String>,
+    pub requires_dist: Option<Vec<String>>,
+    pub classifiers: Option<Vec<String>>,
+    /// Available releases/downloads for this version
+    pub releases: Vec<PypiReleaseInfo>,
+}
+
+/// PyPI release/distribution info
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PypiReleaseInfo {
+    pub filename: String,
+    pub url: String,
+    pub packagetype: String,
+    pub size: Option<i64>,
+    pub digests: Option<serde_json::Value>,
+    pub upload_time: Option<String>,
+}
+
+/// PyPI maintainer info (derived from author/maintainer fields)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PypiMaintainer {
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+impl PypiPackageMetadata {
+    /// Get maintainers from the metadata (author and maintainer fields)
+    pub fn get_maintainers(&self) -> Vec<PypiMaintainer> {
+        let mut maintainers = Vec::new();
+
+        if self.author.is_some() || self.author_email.is_some() {
+            maintainers.push(PypiMaintainer {
+                name: self.author.clone(),
+                email: self.author_email.clone(),
+            });
+        }
+
+        if self.maintainer.is_some() || self.maintainer_email.is_some() {
+            // Only add if different from author
+            let maintainer = PypiMaintainer {
+                name: self.maintainer.clone(),
+                email: self.maintainer_email.clone(),
+            };
+            if maintainer.name != self.author || maintainer.email != self.author_email {
+                maintainers.push(maintainer);
+            }
+        }
+
+        maintainers
+    }
+
+    /// Check if package has a repository URL in project_urls
+    pub fn has_repository(&self) -> bool {
+        if let Some(urls) = &self.project_urls {
+            let repo_keys = [
+                "Source",
+                "Repository",
+                "GitHub",
+                "GitLab",
+                "Bitbucket",
+                "Code",
+            ];
+            for key in repo_keys {
+                if urls.contains_key(key) {
+                    return true;
+                }
+            }
+        }
+        // Also check home_page for common repository hosts
+        if let Some(home) = &self.home_page {
+            let repo_hosts = ["github.com", "gitlab.com", "bitbucket.org"];
+            for host in repo_hosts {
+                if home.contains(host) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/seed/src/main.rs
+++ b/crates/seed/src/main.rs
@@ -1,4 +1,4 @@
-//! Seed script to populate the scan queue with npm packages
+//! Seed script to populate the scan queue with packages from npm or PyPI
 
 use anyhow::Result;
 use clap::Parser;
@@ -8,10 +8,18 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 
-const DOWNLOAD_COUNTS_URL: &str = "https://unpkg.com/download-counts@latest/counts.json";
+/// npm download counts URL
+const NPM_DOWNLOAD_COUNTS_URL: &str = "https://unpkg.com/download-counts@latest/counts.json";
+
+/// PyPI top packages URL (from hugovk/top-pypi-packages)
+const PYPI_TOP_PACKAGES_URL: &str =
+    "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json";
 
 #[derive(Parser)]
-#[command(name = "seed", about = "Seed the scan queue with npm packages")]
+#[command(
+    name = "seed",
+    about = "Seed the scan queue with packages from npm or PyPI"
+)]
 struct Args {
     /// Number of top packages to fetch by download count
     #[arg(short, long, default_value = "1000")]
@@ -20,6 +28,10 @@ struct Args {
     /// Offset to skip the first N packages (for incremental seeding)
     #[arg(short, long, default_value = "0")]
     offset: usize,
+
+    /// Registry to seed packages from (npm or pypi)
+    #[arg(short, long, default_value = "npm")]
+    registry: String,
 
     /// Include AI/agent ecosystem packages
     #[arg(long)]
@@ -63,8 +75,8 @@ struct OsvPackage {
     name: Option<String>,
 }
 
-/// Curated list of AI/agent ecosystem packages
-const AI_PACKAGES: &[&str] = &[
+/// Curated list of AI/agent ecosystem packages (npm)
+const NPM_AI_PACKAGES: &[&str] = &[
     // OpenAI ecosystem
     "openai",
     "gpt-3-encoder",
@@ -110,6 +122,54 @@ const AI_PACKAGES: &[&str] = &[
     "playwright",
 ];
 
+/// Curated list of AI/agent ecosystem packages (PyPI)
+const PYPI_AI_PACKAGES: &[&str] = &[
+    // OpenAI ecosystem
+    "openai",
+    "tiktoken",
+    // Anthropic
+    "anthropic",
+    // LangChain
+    "langchain",
+    "langchain-core",
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain-community",
+    // Vector stores
+    "pinecone-client",
+    "chromadb",
+    "qdrant-client",
+    "weaviate-client",
+    // ML/AI frameworks
+    "transformers",
+    "torch",
+    "tensorflow",
+    "numpy",
+    "pandas",
+    "scikit-learn",
+    // AI utilities
+    "llama-index",
+    "huggingface-hub",
+    "sentence-transformers",
+    "guidance",
+    "instructor",
+    // Agent frameworks
+    "autogen",
+    "crewai",
+    "agentops",
+    // Common in AI pipelines
+    "pydantic",
+    "fastapi",
+    "httpx",
+    "aiohttp",
+    "requests",
+    "beautifulsoup4",
+    "pypdf",
+    "python-docx",
+    // MCP
+    "mcp",
+];
+
 /// Packages known to have install scripts (higher risk)
 const INSTALL_SCRIPT_PACKAGES: &[&str] = &[
     "esbuild",
@@ -141,6 +201,12 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
+    // Parse registry
+    let registry = match args.registry.to_lowercase().as_str() {
+        "pypi" | "python" => Registry::Pypi,
+        _ => Registry::Npm,
+    };
+
     let priority = match args.priority.as_str() {
         "immediate" => ScanPriority::Immediate,
         "high" => ScanPriority::High,
@@ -148,50 +214,90 @@ async fn main() -> Result<()> {
         _ => ScanPriority::Low,
     };
 
-    println!("🌱 sus database seeder\n");
+    let registry_name = match registry {
+        Registry::Npm => "npm",
+        Registry::Pypi => "PyPI",
+        Registry::Crates => "crates.io",
+    };
+
+    println!("🌱 sus database seeder ({})\n", registry_name);
 
     let mut packages: HashSet<String> = HashSet::new();
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300)) // 5 min timeout for large file
         .build()?;
 
-    // 1. Fetch top packages from download-counts
+    // 1. Fetch top packages by download count
     if args.offset > 0 {
         println!(
-            "📦 Fetching packages {} to {} by download count...",
+            "📦 Fetching {} packages {} to {} by download count...",
+            registry_name,
             args.offset + 1,
             args.offset + args.count
         );
     } else {
         println!(
-            "📦 Fetching top {} packages by download count...",
-            args.count
+            "📦 Fetching top {} {} packages by download count...",
+            args.count, registry_name
         );
     }
-    println!("   (downloading ~90MB of npm stats, this may take a moment)");
 
-    match fetch_top_packages(&client, args.count, args.offset).await {
-        Ok(top_packages) => {
-            println!("   Found {} top packages", top_packages.len());
-            packages.extend(top_packages);
+    match registry {
+        Registry::Npm => {
+            println!("   (downloading ~90MB of npm stats, this may take a moment)");
+            match fetch_top_npm_packages(&client, args.count, args.offset).await {
+                Ok(top_packages) => {
+                    println!("   Found {} top packages", top_packages.len());
+                    packages.extend(top_packages);
+                }
+                Err(e) => {
+                    println!("   Warning: Failed to fetch top packages: {}", e);
+                    println!("   Continuing with AI and CVE packages only...");
+                }
+            }
         }
-        Err(e) => {
-            println!("   Warning: Failed to fetch top packages: {}", e);
-            println!("   Continuing with AI and CVE packages only...");
+        Registry::Pypi => {
+            println!("   (downloading PyPI stats from top-pypi-packages)");
+            match fetch_top_pypi_packages(&client, args.count, args.offset).await {
+                Ok(top_packages) => {
+                    println!("   Found {} top packages", top_packages.len());
+                    packages.extend(top_packages);
+                }
+                Err(e) => {
+                    println!("   Warning: Failed to fetch top packages: {}", e);
+                    println!("   Continuing with AI and CVE packages only...");
+                }
+            }
+        }
+        Registry::Crates => {
+            println!("   Warning: crates.io seeding not yet implemented");
         }
     }
 
     // 2. Add AI/agent packages
     if args.include_ai {
         println!("\n🤖 Adding AI/agent ecosystem packages...");
-        for pkg in AI_PACKAGES {
-            packages.insert(pkg.to_string());
+        match registry {
+            Registry::Npm => {
+                for pkg in NPM_AI_PACKAGES {
+                    packages.insert(pkg.to_string());
+                }
+                println!("   Added {} AI packages", NPM_AI_PACKAGES.len());
+            }
+            Registry::Pypi => {
+                for pkg in PYPI_AI_PACKAGES {
+                    packages.insert(pkg.to_string());
+                }
+                println!("   Added {} AI packages", PYPI_AI_PACKAGES.len());
+            }
+            Registry::Crates => {
+                println!("   Warning: crates.io AI packages not yet defined");
+            }
         }
-        println!("   Added {} AI packages", AI_PACKAGES.len());
     }
 
-    // 3. Add packages with known install scripts (only if including AI packages)
-    if args.include_ai {
+    // 3. Add packages with known install scripts (npm only)
+    if args.include_ai && registry == Registry::Npm {
         println!("\n⚠️  Adding packages with install scripts...");
         for pkg in INSTALL_SCRIPT_PACKAGES {
             packages.insert(pkg.to_string());
@@ -205,7 +311,12 @@ async fn main() -> Result<()> {
     // 4. Fetch packages with CVEs
     if args.include_cves {
         println!("\n🔒 Fetching packages with known CVEs...");
-        match fetch_cve_packages(&client).await {
+        let ecosystem = match registry {
+            Registry::Npm => "npm",
+            Registry::Pypi => "PyPI",
+            Registry::Crates => "crates.io",
+        };
+        match fetch_cve_packages(&client, ecosystem).await {
             Ok(cve_packages) => {
                 println!("   Found {} packages with CVEs", cve_packages.len());
                 packages.extend(cve_packages);
@@ -218,7 +329,11 @@ async fn main() -> Result<()> {
 
     // Deduplicate and report
     let packages: Vec<String> = packages.into_iter().collect();
-    println!("\n📊 Total unique packages to seed: {}", packages.len());
+    println!(
+        "\n📊 Total unique {} packages to seed: {}",
+        registry_name,
+        packages.len()
+    );
 
     if args.dry_run {
         println!("\n🔍 Dry run - packages that would be queued:");
@@ -241,7 +356,7 @@ async fn main() -> Result<()> {
         println!("   Note: Queue already has {} pending jobs", existing);
     }
 
-    println!("\n🚀 Pushing packages to scan queue...\n");
+    println!("\n🚀 Pushing {} packages to scan queue...\n", registry_name);
 
     let pb = ProgressBar::new(packages.len() as u64);
     pb.set_style(
@@ -260,7 +375,7 @@ async fn main() -> Result<()> {
             id: uuid::Uuid::new_v4(),
             package: package.clone(),
             version: None, // Will fetch latest
-            registry: Registry::Npm,
+            registry,
             priority,
             requested_at: chrono::Utc::now(),
             requested_by: Some("seed".to_string()),
@@ -280,7 +395,7 @@ async fn main() -> Result<()> {
     pb.finish_and_clear();
 
     println!("✅ Seeding complete!");
-    println!("   Queued: {} packages", success);
+    println!("   Queued: {} {} packages", success, registry_name);
     if failed > 0 {
         println!("   Failed: {} packages", failed);
     }
@@ -291,15 +406,28 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// PyPI top packages response structure
+#[derive(Debug, Deserialize)]
+struct PypiTopPackagesResponse {
+    rows: Vec<PypiPackageRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PypiPackageRow {
+    project: String,
+    #[allow(dead_code)]
+    download_count: u64,
+}
+
 /// Fetch top packages from npm download-counts
-async fn fetch_top_packages(
+async fn fetch_top_npm_packages(
     client: &reqwest::Client,
     count: usize,
     offset: usize,
 ) -> Result<Vec<String>> {
     // Fetch the download counts JSON (this is a large file ~90MB)
     let response = client
-        .get(DOWNLOAD_COUNTS_URL)
+        .get(NPM_DOWNLOAD_COUNTS_URL)
         .header("Accept", "application/json")
         .send()
         .await?;
@@ -325,14 +453,43 @@ async fn fetch_top_packages(
     Ok(top_packages)
 }
 
+/// Fetch top packages from PyPI (via hugovk/top-pypi-packages)
+async fn fetch_top_pypi_packages(
+    client: &reqwest::Client,
+    count: usize,
+    offset: usize,
+) -> Result<Vec<String>> {
+    let response = client
+        .get(PYPI_TOP_PACKAGES_URL)
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("Failed to fetch PyPI top packages: {}", response.status());
+    }
+
+    let data: PypiTopPackagesResponse = response.json().await?;
+
+    let top_packages: Vec<String> = data
+        .rows
+        .into_iter()
+        .skip(offset)
+        .take(count)
+        .map(|r| r.project)
+        .collect();
+
+    Ok(top_packages)
+}
+
 /// Fetch packages with known CVEs from OSV
-async fn fetch_cve_packages(client: &reqwest::Client) -> Result<Vec<String>> {
+async fn fetch_cve_packages(client: &reqwest::Client, ecosystem: &str) -> Result<Vec<String>> {
     let mut packages = HashSet::new();
 
-    // Query OSV for recent npm vulnerabilities
+    // Query OSV for recent vulnerabilities in the specified ecosystem
     let query = serde_json::json!({
         "package": {
-            "ecosystem": "npm"
+            "ecosystem": ecosystem
         }
     });
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { workspace = true }
 semver = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
+zip = { workspace = true }
 tempfile = { workspace = true }
 dotenvy = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -5,7 +5,7 @@ mod skill_generator;
 
 use anyhow::Result;
 use axum::{routing::get, Json, Router};
-use common::{Database, ScanQueue};
+use common::{Database, Registry, ScanQueue};
 use scanner::{AgenticScanner, PackageScanner};
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -88,25 +88,54 @@ async fn worker_loop(queue: ScanQueue, scanner: PackageScanner) {
                     job_id = %job.id,
                     package = %job.package,
                     version = ?job.version,
+                    registry = ?job.registry,
                     tarball = ?job.tarball_path,
                     "Processing scan job"
                 );
 
                 let start = std::time::Instant::now();
 
-                // Handle tarball jobs vs npm registry jobs
+                // Handle tarball jobs vs registry jobs based on registry type
                 let scan_result = if let Some(tarball_path) = &job.tarball_path {
-                    scanner
-                        .scan_tarball(std::path::Path::new(tarball_path))
-                        .await
+                    // Local tarball - determine type based on registry
+                    match job.registry {
+                        Registry::Pypi => {
+                            scanner
+                                .scan_pypi_tarball(std::path::Path::new(tarball_path))
+                                .await
+                        }
+                        _ => {
+                            // Default to npm for tarballs
+                            scanner
+                                .scan_tarball(std::path::Path::new(tarball_path))
+                                .await
+                        }
+                    }
                 } else {
-                    scanner.scan(&job.package, job.version.as_deref()).await
+                    // Remote registry scan
+                    match job.registry {
+                        Registry::Npm => scanner.scan(&job.package, job.version.as_deref()).await,
+                        Registry::Pypi => {
+                            scanner
+                                .scan_pypi(&job.package, job.version.as_deref())
+                                .await
+                        }
+                        Registry::Crates => {
+                            // TODO: Implement crates.io support
+                            tracing::warn!(
+                                package = %job.package,
+                                "Crates.io registry not yet supported"
+                            );
+                            Err(anyhow::anyhow!("Crates.io registry not yet supported"))
+                        }
+                    }
                 };
 
                 match scan_result {
                     Ok(result) => {
                         tracing::info!(
                             package = %job.package,
+                            registry = ?job.registry,
                             risk_level = ?result.risk_level,
                             duration_ms = start.elapsed().as_millis(),
                             "Scan completed"
@@ -122,6 +151,7 @@ async fn worker_loop(queue: ScanQueue, scanner: PackageScanner) {
                     Err(e) => {
                         tracing::error!(
                             package = %job.package,
+                            registry = ?job.registry,
                             error = %e,
                             "Scan failed"
                         );

--- a/crates/worker/src/scanner/agentic.rs
+++ b/crates/worker/src/scanner/agentic.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 const OPENCODE_TIMEOUT_SECS: u64 = 300;
 
 /// Model used for initial threat scanning
-const SCAN_MODEL: &str = "opencode/kimi-k2.5-free";
+const SCAN_MODEL: &str = "anthropic/claude-sonnet-4-5";
 
 /// Model used for threat verification (more capable, used to reduce false positives)
 const VERIFICATION_MODEL: &str = "anthropic/claude-opus-4-5";
@@ -930,7 +930,7 @@ mod tests {
     #[test]
     fn test_model_constants() {
         // Verify model constants are defined correctly
-        assert_eq!(SCAN_MODEL, "opencode/kimi-k2.5-free");
+        assert_eq!(SCAN_MODEL, "anthropic/claude-sonnet-4-5");
         assert_eq!(VERIFICATION_MODEL, "anthropic/claude-opus-4-5");
     }
 }

--- a/crates/worker/src/scanner/capabilities.rs
+++ b/crates/worker/src/scanner/capabilities.rs
@@ -1,10 +1,11 @@
 //! Capability extraction using static analysis
 
 use super::npm::ExtractedPackage;
+use super::pypi::ExtractedPypiPackage;
 use anyhow::Result;
 use common::{
-    EnvironmentCapabilities, FilesystemCapabilities, NetworkCapabilities, PackageCapabilities,
-    PathPermission, ProcessCapabilities,
+    EnvironmentCapabilities, FilesystemCapabilities, NativeCapabilities, NetworkCapabilities,
+    PackageCapabilities, PathPermission, ProcessCapabilities,
 };
 
 /// Known native npm modules
@@ -17,6 +18,22 @@ const KNOWN_NATIVE_MODULES: &[&str] = &[
     "nan",
     "ffi-napi",
     "ref-napi",
+];
+
+/// Known Python native extension packages
+const KNOWN_PYTHON_NATIVE_PACKAGES: &[&str] = &[
+    "cython",
+    "cffi",
+    "pybind11",
+    "numpy",
+    "scipy",
+    "pandas",
+    "pillow",
+    "lxml",
+    "cryptography",
+    "psycopg2",
+    "mysqlclient",
+    "grpcio",
 ];
 
 /// Capability extractor using regex-based static analysis
@@ -65,6 +82,393 @@ impl CapabilityExtractor {
         caps.environment.accessed_vars.dedup();
 
         Ok(caps)
+    }
+
+    /// Extract capabilities from a Python package
+    pub fn extract_python(&self, extracted: &ExtractedPypiPackage) -> Result<PackageCapabilities> {
+        let mut caps = PackageCapabilities::default();
+
+        // Check for native extensions
+        caps.native.has_native = extracted.has_c_extension || extracted.has_cython;
+        if extracted.has_c_extension {
+            caps.native.native_modules.push("C extension".to_string());
+        }
+        if extracted.has_cython {
+            caps.native.native_modules.push("Cython".to_string());
+        }
+
+        // Analyze Python source files
+        for file in &extracted.source_files {
+            self.analyze_python_source(&file.content, &mut caps);
+        }
+
+        // Deduplicate
+        caps.network.domains.sort();
+        caps.network.domains.dedup();
+        caps.network.protocols.sort();
+        caps.network.protocols.dedup();
+        caps.process.commands.sort();
+        caps.process.commands.dedup();
+        caps.environment.accessed_vars.sort();
+        caps.environment.accessed_vars.dedup();
+        caps.native.native_modules.sort();
+        caps.native.native_modules.dedup();
+
+        Ok(caps)
+    }
+
+    /// Analyze Python source code for capabilities
+    fn analyze_python_source(&self, source: &str, caps: &mut PackageCapabilities) {
+        // Network detection
+        self.detect_python_network(source, &mut caps.network);
+
+        // Filesystem detection
+        self.detect_python_filesystem(source, &mut caps.filesystem);
+
+        // Process detection
+        self.detect_python_process(source, &mut caps.process);
+
+        // Environment detection
+        self.detect_python_environment(source, &mut caps.environment);
+
+        // Native module detection
+        self.detect_python_native(source, &mut caps.native);
+    }
+
+    /// Detect network capabilities in Python code
+    fn detect_python_network(&self, source: &str, caps: &mut NetworkCapabilities) {
+        // Common Python network patterns
+        let network_patterns = [
+            // requests library
+            "requests.get",
+            "requests.post",
+            "requests.put",
+            "requests.delete",
+            "requests.patch",
+            "requests.request",
+            // urllib
+            "urllib.request",
+            "urllib.urlopen",
+            "urlopen(",
+            // httpx
+            "httpx.get",
+            "httpx.post",
+            "httpx.AsyncClient",
+            "httpx.Client",
+            // aiohttp
+            "aiohttp.ClientSession",
+            "aiohttp.request",
+            // socket
+            "socket.socket",
+            "socket.create_connection",
+            // httplib/http.client
+            "http.client",
+            "HTTPConnection",
+            "HTTPSConnection",
+        ];
+
+        for pattern in network_patterns {
+            if source.contains(pattern) {
+                caps.makes_requests = true;
+                break;
+            }
+        }
+
+        // Also check for import statements
+        let import_patterns = [
+            "import requests",
+            "from requests",
+            "import urllib",
+            "from urllib",
+            "import httpx",
+            "from httpx",
+            "import aiohttp",
+            "from aiohttp",
+            "import socket",
+            "from socket",
+        ];
+
+        for pattern in import_patterns {
+            if source.contains(pattern) {
+                caps.makes_requests = true;
+                break;
+            }
+        }
+
+        // Extract domains from URLs
+        self.extract_domains(source, caps);
+
+        // Detect protocols
+        if source.contains("http://") {
+            caps.protocols.push("http".to_string());
+        }
+        if source.contains("https://") {
+            caps.protocols.push("https".to_string());
+        }
+        if source.contains("ws://") || source.contains("wss://") {
+            caps.protocols.push("websocket".to_string());
+        }
+        if source.contains("socket.SOCK_STREAM") {
+            caps.protocols.push("tcp".to_string());
+        }
+        if source.contains("socket.SOCK_DGRAM") {
+            caps.protocols.push("udp".to_string());
+        }
+    }
+
+    /// Detect filesystem capabilities in Python code
+    fn detect_python_filesystem(&self, source: &str, caps: &mut FilesystemCapabilities) {
+        // Read patterns
+        let read_patterns = [
+            "open(",
+            ".read(",
+            ".readline(",
+            ".readlines(",
+            "Path.read_text",
+            "Path.read_bytes",
+            "os.listdir",
+            "os.scandir",
+            "pathlib.Path",
+            "glob.glob",
+            "glob.iglob",
+            "shutil.copy",
+            "json.load(",
+            "yaml.safe_load",
+            "configparser",
+        ];
+
+        for pattern in read_patterns {
+            if source.contains(pattern) {
+                caps.reads = true;
+                break;
+            }
+        }
+
+        // Write patterns
+        let write_patterns = [
+            ".write(",
+            ".writelines(",
+            "Path.write_text",
+            "Path.write_bytes",
+            "os.mkdir",
+            "os.makedirs",
+            "os.remove",
+            "os.unlink",
+            "os.rmdir",
+            "shutil.rmtree",
+            "shutil.move",
+            "shutil.copy",
+            "json.dump(",
+            "yaml.dump",
+        ];
+
+        for pattern in write_patterns {
+            if source.contains(pattern) {
+                caps.writes = true;
+                break;
+            }
+        }
+
+        // Check for write mode in open()
+        if source.contains("open(") {
+            let write_modes = [
+                "'w'", "\"w\"", "'a'", "\"a\"", "'wb'", "\"wb\"", "'ab'", "\"ab\"",
+            ];
+            for mode in write_modes {
+                if source.contains(mode) {
+                    caps.writes = true;
+                    break;
+                }
+            }
+        }
+
+        // Extract paths
+        self.extract_python_paths(source, caps);
+    }
+
+    /// Extract file paths from Python source
+    fn extract_python_paths(&self, source: &str, caps: &mut FilesystemCapabilities) {
+        let path_indicators = [
+            "/tmp/",
+            "/var/",
+            "/etc/",
+            "/home/",
+            "/usr/",
+            "~/.config",
+            "~/.local",
+            ".env",
+            "__pycache__",
+            "site-packages",
+            "requirements.txt",
+            "setup.py",
+            "pyproject.toml",
+        ];
+
+        for indicator in path_indicators {
+            if source.contains(indicator) {
+                let mode = match (caps.reads, caps.writes) {
+                    (true, true) => "rw",
+                    (true, false) => "r",
+                    (false, true) => "w",
+                    _ => "r",
+                };
+
+                caps.paths.push(PathPermission {
+                    path: indicator.to_string(),
+                    mode: mode.to_string(),
+                });
+            }
+        }
+    }
+
+    /// Detect process spawning capabilities in Python code
+    fn detect_python_process(&self, source: &str, caps: &mut ProcessCapabilities) {
+        let spawn_patterns = [
+            "subprocess.run",
+            "subprocess.call",
+            "subprocess.Popen",
+            "subprocess.check_output",
+            "subprocess.check_call",
+            "os.system(",
+            "os.popen(",
+            "os.exec",
+            "os.spawn",
+            "os.fork(",
+            "multiprocessing.Process",
+            "concurrent.futures.ProcessPoolExecutor",
+        ];
+
+        for pattern in spawn_patterns {
+            if source.contains(pattern) {
+                caps.spawns_children = true;
+                break;
+            }
+        }
+
+        // Also check imports
+        let import_patterns = [
+            "import subprocess",
+            "from subprocess",
+            "import multiprocessing",
+            "from multiprocessing",
+        ];
+
+        for pattern in import_patterns {
+            if source.contains(pattern) {
+                caps.spawns_children = true;
+                break;
+            }
+        }
+
+        // Extract command names
+        self.extract_python_commands(source, caps);
+    }
+
+    /// Extract command names from Python subprocess calls
+    fn extract_python_commands(&self, source: &str, caps: &mut ProcessCapabilities) {
+        let common_commands = [
+            "python", "pip", "git", "curl", "wget", "sh", "bash", "rm", "chmod", "chown", "sudo",
+            "apt", "yum", "npm", "node", "docker", "kubectl",
+        ];
+
+        for cmd in common_commands {
+            // Look for command in various subprocess patterns
+            let patterns = [
+                format!("subprocess.run(['{}", cmd),
+                format!("subprocess.run([\"{}", cmd),
+                format!("subprocess.call(['{}", cmd),
+                format!("subprocess.call([\"{}", cmd),
+                format!("Popen(['{}", cmd),
+                format!("Popen([\"{}", cmd),
+                format!("os.system('{}", cmd),
+                format!("os.system(\"{}", cmd),
+            ];
+
+            for pattern in patterns {
+                if source.contains(&pattern) {
+                    caps.commands.push(cmd.to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Detect environment variable access in Python code
+    fn detect_python_environment(&self, source: &str, caps: &mut EnvironmentCapabilities) {
+        // os.environ access
+        let env_patterns = [
+            "os.environ[",
+            "os.environ.get(",
+            "os.getenv(",
+            "environ.get(",
+            "environ[",
+        ];
+
+        for pattern in env_patterns {
+            let mut search_from = 0;
+            while let Some(start) = source[search_from..].find(pattern) {
+                let abs_start = search_from + start + pattern.len();
+                if abs_start >= source.len() {
+                    break;
+                }
+
+                // Find the variable name
+                let remaining = &source[abs_start..];
+                let end_chars = [')', ']', ',', ' '];
+
+                // Skip quote character
+                let var_start = if remaining.starts_with('"') || remaining.starts_with('\'') {
+                    1
+                } else {
+                    0
+                };
+
+                if var_start >= remaining.len() {
+                    break;
+                }
+
+                let remaining = &remaining[var_start..];
+                let var_end = remaining
+                    .find(|c: char| c == '"' || c == '\'' || end_chars.contains(&c))
+                    .unwrap_or(remaining.len());
+
+                let var_name = &remaining[..var_end];
+
+                if !var_name.is_empty() && var_name.len() < 50 {
+                    caps.accessed_vars.push(var_name.to_string());
+                }
+
+                search_from = abs_start + var_end + 1;
+            }
+        }
+    }
+
+    /// Detect native module usage in Python code
+    fn detect_python_native(&self, source: &str, caps: &mut NativeCapabilities) {
+        // Check for imports of known native packages
+        for pkg in KNOWN_PYTHON_NATIVE_PACKAGES {
+            let patterns = [format!("import {}", pkg), format!("from {} import", pkg)];
+
+            for pattern in patterns {
+                if source.contains(&pattern) {
+                    caps.has_native = true;
+                    caps.native_modules.push(pkg.to_string());
+                    break;
+                }
+            }
+        }
+
+        // Check for ctypes usage
+        if source.contains("import ctypes") || source.contains("from ctypes") {
+            caps.has_native = true;
+            caps.native_modules.push("ctypes".to_string());
+        }
+
+        // Check for CFFI
+        if source.contains("from cffi import") || source.contains("import cffi") {
+            caps.has_native = true;
+            caps.native_modules.push("cffi".to_string());
+        }
     }
 
     /// Analyze source code for capabilities

--- a/crates/worker/src/scanner/cve.rs
+++ b/crates/worker/src/scanner/cve.rs
@@ -71,17 +71,34 @@ impl CveScanner {
         }
     }
 
-    /// Scan for CVEs affecting a package version
+    /// Scan for CVEs affecting a package version (defaults to npm ecosystem)
     pub async fn scan(&self, package: &str, version: &str) -> Result<Vec<CveSummary>> {
+        self.scan_with_ecosystem(package, version, "npm").await
+    }
+
+    /// Scan for CVEs affecting a package version with a specific ecosystem
+    pub async fn scan_with_ecosystem(
+        &self,
+        package: &str,
+        version: &str,
+        ecosystem: &str,
+    ) -> Result<Vec<CveSummary>> {
         let url = format!("{}/query", self.osv_url);
 
         let request = OsvQueryRequest {
             package: OsvPackage {
                 name: package.to_string(),
-                ecosystem: "npm".to_string(),
+                ecosystem: ecosystem.to_string(),
             },
             version: version.to_string(),
         };
+
+        tracing::debug!(
+            package,
+            version,
+            ecosystem,
+            "Querying OSV for vulnerabilities"
+        );
 
         let response = self.client.post(&url).json(&request).send().await?;
 
@@ -97,6 +114,16 @@ impl CveScanner {
         let osv_response: OsvQueryResponse = response.json().await?;
 
         let vulns = osv_response.vulns.unwrap_or_default();
+
+        if !vulns.is_empty() {
+            tracing::info!(
+                package,
+                version,
+                ecosystem,
+                count = vulns.len(),
+                "Found vulnerabilities"
+            );
+        }
 
         let cves: Vec<CveSummary> = vulns
             .into_iter()

--- a/crates/worker/src/scanner/mod.rs
+++ b/crates/worker/src/scanner/mod.rs
@@ -4,6 +4,7 @@ mod agentic;
 mod capabilities;
 mod cve;
 mod npm;
+pub mod pypi;
 
 use crate::skill_generator::generate_skill_md;
 use anyhow::Result;
@@ -11,11 +12,12 @@ use capabilities::CapabilityExtractor;
 use chrono::{DateTime, Utc};
 use common::{
     db::{NewAgenticThreat, NewPackage, NewPackageCve},
-    AgenticThreatSummary, CveSummary, Database, NpmPackageMetadata, PackageCapabilities, Registry,
-    RiskLevel, UsageDocs,
+    AgenticThreatSummary, CveSummary, Database, NpmPackageMetadata, PackageCapabilities,
+    PypiPackageMetadata, Registry, RiskLevel, UsageDocs,
 };
 use cve::CveScanner;
 use npm::NpmClient;
+use pypi::PypiClient;
 
 // Re-export AgenticScanner for OpenCode installation check from main.rs
 pub use agentic::AgenticScanner;
@@ -137,6 +139,188 @@ pub fn calculate_risk(
     (max_level, reasons)
 }
 
+/// Calculate trust score (0-100) for PyPI packages
+///
+/// Scoring:
+/// - Base score: 50
+/// - Has author: +5
+/// - Has maintainer: +5
+/// - Has repository URL: +10
+/// - Has description: +5
+/// - Has license: +5
+/// - Has classifiers: +5
+/// - Development Status stable: +10
+pub fn calculate_trust_score_pypi(metadata: Option<&PypiPackageMetadata>) -> u8 {
+    let mut score = 50u8; // Base score
+
+    let Some(metadata) = metadata else {
+        return score;
+    };
+
+    // Has author (+5)
+    if metadata.author.is_some() {
+        score = score.saturating_add(5);
+    }
+
+    // Has maintainer (+5)
+    if metadata.maintainer.is_some() {
+        score = score.saturating_add(5);
+    }
+
+    // Has repository URL (+10)
+    if metadata.has_repository() {
+        score = score.saturating_add(10);
+    }
+
+    // Has description (+5)
+    if metadata.summary.is_some() {
+        score = score.saturating_add(5);
+    }
+
+    // Has license (+5)
+    if metadata.license.is_some() {
+        score = score.saturating_add(5);
+    }
+
+    // Has classifiers (+5)
+    if let Some(classifiers) = &metadata.classifiers {
+        if !classifiers.is_empty() {
+            score = score.saturating_add(5);
+
+            // Check for stable development status (+10)
+            for classifier in classifiers {
+                if classifier.contains("Development Status :: 5 - Production/Stable")
+                    || classifier.contains("Development Status :: 6 - Mature")
+                {
+                    score = score.saturating_add(10);
+                    break;
+                }
+            }
+        }
+    }
+
+    score.min(100)
+}
+
+/// Convert PyPI extracted package to npm-style format for agentic scanner
+fn convert_pypi_to_npm_format(extracted: &pypi::ExtractedPypiPackage) -> npm::ExtractedPackage {
+    // Convert Python source files to the generic SourceFile format
+    let source_files = extracted
+        .source_files
+        .iter()
+        .map(|f| npm::SourceFile {
+            content: f.content.clone(),
+        })
+        .collect();
+
+    npm::ExtractedPackage {
+        dir: tempfile::TempDir::new().expect("Failed to create temp dir"),
+        root: extracted.root.clone(),
+        package_json: extracted.metadata.clone(),
+        source_files,
+        has_binding_gyp: false,
+        has_napi: extracted.has_c_extension || extracted.has_cython,
+    }
+}
+
+/// Extract package name and version from PyPI metadata
+fn extract_pypi_name_version(metadata: &serde_json::Value) -> Result<(String, String)> {
+    // Try to parse from PKG-INFO or pyproject.toml content
+    if let Some(content) = metadata.get("content").and_then(|c| c.as_str()) {
+        let metadata_type = metadata.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        if metadata_type == "PKG-INFO" || metadata_type == "METADATA" {
+            // Parse PKG-INFO format (email-like headers)
+            let mut name = None;
+            let mut version = None;
+
+            for line in content.lines() {
+                if let Some(n) = line.strip_prefix("Name: ") {
+                    name = Some(n.trim().to_string());
+                } else if let Some(v) = line.strip_prefix("Version: ") {
+                    version = Some(v.trim().to_string());
+                }
+                if name.is_some() && version.is_some() {
+                    break;
+                }
+            }
+
+            if let (Some(n), Some(v)) = (name, version) {
+                return Ok((n, v));
+            }
+        } else if metadata_type == "pyproject.toml" {
+            // Basic TOML parsing for name and version
+            for line in content.lines() {
+                let line = line.trim();
+                if line.starts_with("name") {
+                    if let Some(v) = extract_toml_string_value(line) {
+                        if let Some(version) = find_toml_version(content) {
+                            return Ok((v, version));
+                        }
+                    }
+                }
+            }
+        } else if metadata_type == "setup.py" {
+            // Very basic setup.py parsing - look for name= and version=
+            if let (Some(name), Some(version)) = (
+                extract_setup_py_value(content, "name"),
+                extract_setup_py_value(content, "version"),
+            ) {
+                return Ok((name, version));
+            }
+        }
+    }
+
+    anyhow::bail!("Could not extract package name and version from metadata")
+}
+
+/// Extract a string value from a TOML line like: name = "value"
+fn extract_toml_string_value(line: &str) -> Option<String> {
+    let parts: Vec<&str> = line.splitn(2, '=').collect();
+    if parts.len() == 2 {
+        let value = parts[1].trim();
+        // Remove quotes
+        if (value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\''))
+        {
+            return Some(value[1..value.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+/// Find version in TOML content
+fn find_toml_version(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("version") {
+            return extract_toml_string_value(line);
+        }
+    }
+    None
+}
+
+/// Extract a value from setup.py like: name="value" or name='value'
+fn extract_setup_py_value(content: &str, key: &str) -> Option<String> {
+    let patterns = [
+        format!("{}=\"", key),
+        format!("{}='", key),
+        format!("{} = \"", key),
+        format!("{} = '", key),
+    ];
+
+    for pattern in &patterns {
+        if let Some(start) = content.find(pattern) {
+            let value_start = start + pattern.len();
+            let quote_char = if pattern.ends_with('"') { '"' } else { '\'' };
+            if let Some(end) = content[value_start..].find(quote_char) {
+                return Some(content[value_start..value_start + end].to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Result of scanning a package
 #[allow(dead_code)]
 pub struct ScanResult {
@@ -155,6 +339,7 @@ pub struct ScanResult {
 pub struct PackageScanner {
     db: Database,
     npm: NpmClient,
+    pypi: PypiClient,
     cve_scanner: CveScanner,
     agentic_scanner: AgenticScanner,
     capability_extractor: CapabilityExtractor,
@@ -169,6 +354,7 @@ impl PackageScanner {
         Self {
             db,
             npm: NpmClient::new(),
+            pypi: PypiClient::new(),
             cve_scanner: CveScanner::new(),
             agentic_scanner: AgenticScanner::new(None),
             capability_extractor: CapabilityExtractor::new(),
@@ -236,6 +422,193 @@ impl PackageScanner {
 
         self.scan_extracted(&package, &version, None, None, extracted)
             .await
+    }
+
+    /// Scan a package from PyPI registry
+    pub async fn scan_pypi(&self, package: &str, version: Option<&str>) -> Result<ScanResult> {
+        // 1. Fetch package metadata
+        tracing::debug!(package, "Fetching PyPI package metadata");
+        let metadata = self.pypi.fetch_metadata(package).await?;
+
+        // Determine version to scan
+        let version = match version {
+            Some(v) => v.to_string(),
+            None => metadata.version.clone(),
+        };
+
+        // 2. Download and extract package
+        tracing::debug!(package, version = %version, "Downloading PyPI package");
+        let extracted = self.pypi.download_and_extract(package, &version).await?;
+
+        self.scan_pypi_extracted(package, &version, Some(&metadata), extracted)
+            .await
+    }
+
+    /// Scan a local Python package file
+    pub async fn scan_pypi_tarball(&self, path: &std::path::Path) -> Result<ScanResult> {
+        tracing::debug!(path = ?path, "Extracting local Python package");
+        let extracted = self.pypi.extract_local_package(path)?;
+
+        // Try to extract name/version from metadata
+        let (package, version) = extract_pypi_name_version(&extracted.metadata)?;
+
+        self.scan_pypi_extracted(&package, &version, None, extracted)
+            .await
+    }
+
+    /// Common scanning logic for extracted PyPI packages
+    async fn scan_pypi_extracted(
+        &self,
+        package: &str,
+        version: &str,
+        metadata: Option<&PypiPackageMetadata>,
+        extracted: pypi::ExtractedPypiPackage,
+    ) -> Result<ScanResult> {
+        // Convert PyPI source files to the format expected by agentic scanner
+        let npm_style_extracted = convert_pypi_to_npm_format(&extracted);
+
+        // Run all analyses in parallel
+        let (cves, agentic_threats, capabilities, usage_docs) = tokio::join!(
+            self.cve_scanner
+                .scan_with_ecosystem(package, version, "PyPI"),
+            self.agentic_scanner.scan(&npm_style_extracted),
+            async { self.capability_extractor.extract_python(&extracted) },
+            self.agentic_scanner
+                .generate_usage_docs(&npm_style_extracted, package)
+        );
+
+        let cves = cves.unwrap_or_else(|e| {
+            tracing::warn!("CVE scan failed: {}", e);
+            vec![]
+        });
+
+        let agentic_threats = agentic_threats.unwrap_or_else(|e| {
+            tracing::warn!("Agentic scan failed: {}", e);
+            vec![]
+        });
+
+        // Verify threats if any were detected
+        let agentic_threats = if !agentic_threats.is_empty() {
+            tracing::info!(
+                "Verifying {} detected threats with secondary model",
+                agentic_threats.len()
+            );
+            match self
+                .agentic_scanner
+                .verify_threats(&npm_style_extracted, agentic_threats.clone())
+                .await
+            {
+                Ok(verified) => verified,
+                Err(e) => {
+                    tracing::warn!(
+                        "Threat verification failed, keeping original {} threats: {}",
+                        agentic_threats.len(),
+                        e
+                    );
+                    agentic_threats
+                }
+            }
+        } else {
+            agentic_threats
+        };
+
+        let capabilities = capabilities.unwrap_or_default();
+
+        let usage_docs = usage_docs.unwrap_or_else(|e| {
+            tracing::warn!("Usage docs generation failed: {}", e);
+            UsageDocs::default()
+        });
+
+        // Calculate trust score for PyPI packages
+        let trust_score = calculate_trust_score_pypi(metadata);
+
+        // Determine risk level
+        let (risk_level, risk_reasons) =
+            calculate_risk(&cves, &agentic_threats, &capabilities, trust_score);
+
+        // Generate SKILL.md
+        let skill_md = generate_skill_md(
+            package,
+            version,
+            &capabilities,
+            &risk_level,
+            &risk_reasons,
+            &usage_docs,
+        );
+
+        // Fetch download stats (non-blocking)
+        let weekly_downloads = self
+            .pypi
+            .fetch_weekly_downloads(package)
+            .await
+            .unwrap_or(None);
+
+        // Get maintainers from metadata
+        let maintainers = metadata.map(|m| m.get_maintainers());
+
+        // Save to database
+        let package_id = self
+            .db
+            .upsert_package(&NewPackage {
+                name: package.to_string(),
+                version: version.to_string(),
+                registry: Registry::Pypi,
+                risk_level,
+                risk_reasons: serde_json::to_value(&risk_reasons)?,
+                trust_score: Some(trust_score as i16),
+                publisher_verified: None,
+                weekly_downloads,
+                maintainer_count: maintainers.as_ref().map(|m| m.len() as i32),
+                maintainers: maintainers.map(|m| serde_json::to_value(m).unwrap_or_default()),
+                last_publish: None, // PyPI doesn't provide per-version timestamps in the same way
+                capabilities: serde_json::to_value(&capabilities)?,
+                skill_md: Some(skill_md.clone()),
+                scan_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            })
+            .await?;
+
+        // Clear old CVEs and threats
+        self.db.delete_package_cves(package_id).await?;
+        self.db.delete_package_threats(package_id).await?;
+
+        // Insert new CVEs
+        for cve in &cves {
+            self.db
+                .insert_cve(&NewPackageCve {
+                    package_id,
+                    cve_id: cve.cve_id.clone(),
+                    severity: cve.severity.clone(),
+                    description: cve.description.clone(),
+                    fixed_in: cve.fixed_in.clone(),
+                    published_at: None,
+                })
+                .await?;
+        }
+
+        // Insert new threats
+        for threat in &agentic_threats {
+            self.db
+                .insert_threat(&NewAgenticThreat {
+                    package_id,
+                    threat_type: threat.threat_type,
+                    confidence: threat.confidence,
+                    location: threat.location.clone(),
+                    snippet: threat.snippet.clone(),
+                })
+                .await?;
+        }
+
+        Ok(ScanResult {
+            package: package.to_string(),
+            version: version.to_string(),
+            risk_level,
+            risk_reasons,
+            trust_score,
+            cves,
+            agentic_threats,
+            capabilities,
+            skill_md,
+        })
     }
 
     /// Common scanning logic for extracted packages

--- a/crates/worker/src/scanner/pypi.rs
+++ b/crates/worker/src/scanner/pypi.rs
@@ -1,0 +1,672 @@
+//! PyPI registry client
+
+use anyhow::{Context, Result};
+use common::{PypiPackageMetadata, PypiReleaseInfo};
+use flate2::read::GzDecoder;
+use reqwest::Client;
+use std::path::{Path, PathBuf};
+use tar::Archive;
+use tempfile::TempDir;
+use zip::ZipArchive;
+
+/// Extracted Python package contents
+pub struct ExtractedPypiPackage {
+    /// Temporary directory containing extracted files (must keep for ownership)
+    #[allow(dead_code)]
+    pub dir: TempDir,
+    /// Path to package root
+    pub root: PathBuf,
+    /// Package metadata (from PKG-INFO or pyproject.toml)
+    pub metadata: serde_json::Value,
+    /// Source files (.py, .pyi)
+    pub source_files: Vec<PythonSourceFile>,
+    /// Has C extensions
+    pub has_c_extension: bool,
+    /// Has Cython files
+    pub has_cython: bool,
+}
+
+/// A Python source file
+pub struct PythonSourceFile {
+    #[allow(dead_code)]
+    pub path: String,
+    pub content: String,
+}
+
+/// Client for PyPI registry
+pub struct PypiClient {
+    client: Client,
+    registry_url: String,
+}
+
+impl PypiClient {
+    /// Create a new PyPI client
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .user_agent(format!("sus-worker/{}", env!("CARGO_PKG_VERSION")))
+                .build()
+                .expect("Failed to create HTTP client"),
+            registry_url: std::env::var("PYPI_REGISTRY_URL")
+                .unwrap_or_else(|_| "https://pypi.org/pypi".to_string()),
+        }
+    }
+
+    /// Fetch package metadata (all versions)
+    pub async fn fetch_metadata(&self, package: &str) -> Result<PypiPackageMetadata> {
+        let url = format!(
+            "{}/{}/json",
+            self.registry_url,
+            normalize_package_name(package)
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch package metadata")?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!("Package '{}' not found on PyPI", package);
+        }
+
+        let json: serde_json::Value = response
+            .error_for_status()
+            .context("PyPI registry returned an error")?
+            .json()
+            .await
+            .context("Failed to parse package metadata")?;
+
+        parse_pypi_metadata(&json)
+    }
+
+    /// Fetch specific version info
+    pub async fn fetch_version_info(
+        &self,
+        package: &str,
+        version: &str,
+    ) -> Result<PypiPackageMetadata> {
+        let url = format!(
+            "{}/{}/{}/json",
+            self.registry_url,
+            normalize_package_name(package),
+            version
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch version info")?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!("Package '{}@{}' not found on PyPI", package, version);
+        }
+
+        let json: serde_json::Value = response
+            .error_for_status()
+            .context("PyPI registry returned an error")?
+            .json()
+            .await
+            .context("Failed to parse version info")?;
+
+        parse_pypi_metadata(&json)
+    }
+
+    /// Download and extract package source distribution
+    pub async fn download_and_extract(
+        &self,
+        package: &str,
+        version: &str,
+    ) -> Result<ExtractedPypiPackage> {
+        // Get package info to find download URL
+        let metadata = self.fetch_version_info(package, version).await?;
+
+        // Find the best release to download (prefer sdist over wheel for source analysis)
+        let release = metadata
+            .releases
+            .iter()
+            .find(|r| r.packagetype == "sdist")
+            .or_else(|| {
+                metadata
+                    .releases
+                    .iter()
+                    .find(|r| r.packagetype == "bdist_wheel")
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!("No downloadable release found for {}@{}", package, version)
+            })?;
+
+        tracing::debug!(
+            "Downloading {} ({}) from {}",
+            package,
+            release.packagetype,
+            release.url
+        );
+
+        // Download the release
+        let response = self
+            .client
+            .get(&release.url)
+            .send()
+            .await
+            .context("Failed to download package")?;
+
+        let bytes = response
+            .error_for_status()
+            .context("Failed to download package")?
+            .bytes()
+            .await?;
+
+        // Create temp directory
+        let dir = TempDir::new().context("Failed to create temp directory")?;
+
+        // Extract based on file type
+        let root = if release.filename.ends_with(".tar.gz") || release.filename.ends_with(".tgz") {
+            extract_tarball(&bytes, dir.path())?
+        } else if release.filename.ends_with(".whl") || release.filename.ends_with(".zip") {
+            extract_zip(&bytes, dir.path())?
+        } else {
+            anyhow::bail!("Unsupported package format: {}", release.filename);
+        };
+
+        // Read package metadata
+        let pkg_metadata = read_package_metadata(&root)?;
+
+        // Check for native extensions
+        let has_c_extension = check_for_c_extensions(&root);
+        let has_cython = check_for_cython(&root);
+
+        // Collect Python source files
+        let source_files = collect_python_source_files(&root)?;
+
+        Ok(ExtractedPypiPackage {
+            dir,
+            root,
+            metadata: pkg_metadata,
+            source_files,
+            has_c_extension,
+            has_cython,
+        })
+    }
+
+    /// Extract a local tarball or wheel file (for uploaded packages)
+    pub fn extract_local_package(&self, path: &Path) -> Result<ExtractedPypiPackage> {
+        let bytes = std::fs::read(path).context(format!("Failed to read package: {:?}", path))?;
+
+        let dir = TempDir::new().context("Failed to create temp directory")?;
+
+        let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+        let root = if filename.ends_with(".tar.gz") || filename.ends_with(".tgz") {
+            extract_tarball(&bytes, dir.path())?
+        } else if filename.ends_with(".whl") || filename.ends_with(".zip") {
+            extract_zip(&bytes, dir.path())?
+        } else {
+            anyhow::bail!("Unsupported package format: {}", filename);
+        };
+
+        let pkg_metadata = read_package_metadata(&root)?;
+        let has_c_extension = check_for_c_extensions(&root);
+        let has_cython = check_for_cython(&root);
+        let source_files = collect_python_source_files(&root)?;
+
+        Ok(ExtractedPypiPackage {
+            dir,
+            root,
+            metadata: pkg_metadata,
+            source_files,
+            has_c_extension,
+            has_cython,
+        })
+    }
+
+    /// Fetch download statistics from pypistats.org
+    pub async fn fetch_weekly_downloads(&self, package: &str) -> Result<Option<i64>> {
+        let url = format!(
+            "https://pypistats.org/api/packages/{}/recent",
+            normalize_package_name(package)
+        );
+
+        let response = self.client.get(&url).send().await;
+
+        match response {
+            Ok(resp) => {
+                if !resp.status().is_success() {
+                    tracing::debug!("pypistats API returned {} for {}", resp.status(), package);
+                    return Ok(None);
+                }
+
+                let json: serde_json::Value = resp.json().await.unwrap_or_default();
+                // pypistats returns {"data": {"last_week": 12345, ...}}
+                Ok(json
+                    .get("data")
+                    .and_then(|d| d.get("last_week"))
+                    .and_then(|w| w.as_i64()))
+            }
+            Err(e) => {
+                tracing::debug!("Failed to fetch downloads for {}: {}", package, e);
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Normalize package name according to PEP 503
+/// (lowercase, replace hyphens/underscores with hyphens)
+fn normalize_package_name(name: &str) -> String {
+    name.to_lowercase().replace('_', "-")
+}
+
+/// Parse PyPI JSON API response into our metadata struct
+fn parse_pypi_metadata(json: &serde_json::Value) -> Result<PypiPackageMetadata> {
+    let info = json
+        .get("info")
+        .ok_or_else(|| anyhow::anyhow!("Missing 'info' in PyPI response"))?;
+
+    let name = info
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let version = info
+        .get("version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let summary = info
+        .get("summary")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let author = info
+        .get("author")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let author_email = info
+        .get("author_email")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let maintainer = info
+        .get("maintainer")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let maintainer_email = info
+        .get("maintainer_email")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let home_page = info
+        .get("home_page")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let project_url = info
+        .get("project_url")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let project_urls = info
+        .get("project_urls")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        });
+
+    let license = info
+        .get("license")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let requires_python = info
+        .get("requires_python")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let requires_dist = info
+        .get("requires_dist")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
+
+    let classifiers = info
+        .get("classifiers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
+
+    // Parse releases (URLs array in the response)
+    let releases = json
+        .get("urls")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|r| {
+                    Some(PypiReleaseInfo {
+                        filename: r.get("filename")?.as_str()?.to_string(),
+                        url: r.get("url")?.as_str()?.to_string(),
+                        packagetype: r.get("packagetype")?.as_str()?.to_string(),
+                        size: r.get("size").and_then(|v| v.as_i64()),
+                        digests: r.get("digests").cloned(),
+                        upload_time: r
+                            .get("upload_time")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(PypiPackageMetadata {
+        name,
+        version,
+        summary,
+        author,
+        author_email,
+        maintainer,
+        maintainer_email,
+        home_page,
+        project_url,
+        project_urls,
+        license,
+        requires_python,
+        requires_dist,
+        classifiers,
+        releases,
+    })
+}
+
+/// Extract a .tar.gz archive
+fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<PathBuf> {
+    let decoder = GzDecoder::new(bytes);
+    let mut archive = Archive::new(decoder);
+
+    archive.unpack(dest).context("Failed to extract tarball")?;
+
+    // Find the root directory (usually {package}-{version}/)
+    find_package_root(dest)
+}
+
+/// Extract a .zip or .whl archive
+fn extract_zip(bytes: &[u8], dest: &Path) -> Result<PathBuf> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = ZipArchive::new(cursor).context("Failed to open zip archive")?;
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let outpath = dest.join(file.mangled_name());
+
+        if file.name().ends_with('/') {
+            std::fs::create_dir_all(&outpath)?;
+        } else {
+            if let Some(parent) = outpath.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut outfile = std::fs::File::create(&outpath)?;
+            std::io::copy(&mut file, &mut outfile)?;
+        }
+    }
+
+    // For wheels, the root is the dest directory itself
+    // For zip source dists, find the root directory
+    find_package_root(dest)
+}
+
+/// Find the package root directory after extraction
+fn find_package_root(dest: &Path) -> Result<PathBuf> {
+    // Look for the first directory, or return dest if it contains Python files directly
+    let entries: Vec<_> = std::fs::read_dir(dest)?.filter_map(|e| e.ok()).collect();
+
+    // If there's exactly one directory, use it as root
+    if entries.len() == 1 && entries[0].path().is_dir() {
+        return Ok(entries[0].path());
+    }
+
+    // If there are Python files or a setup.py directly in dest, use dest
+    for entry in &entries {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.ends_with(".py") || name_str == "setup.py" || name_str == "pyproject.toml" {
+            return Ok(dest.to_path_buf());
+        }
+    }
+
+    // Look for a directory that looks like {package}-{version}
+    for entry in entries {
+        if entry.path().is_dir() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            // Skip dist-info and egg-info directories
+            if !name_str.ends_with(".dist-info") && !name_str.ends_with(".egg-info") {
+                return Ok(entry.path());
+            }
+        }
+    }
+
+    // Fallback to dest
+    Ok(dest.to_path_buf())
+}
+
+/// Read package metadata from PKG-INFO, pyproject.toml, or setup.py
+fn read_package_metadata(root: &Path) -> Result<serde_json::Value> {
+    // Try PKG-INFO first (standard metadata file)
+    let pkg_info_path = root.join("PKG-INFO");
+    if pkg_info_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&pkg_info_path) {
+            return Ok(serde_json::json!({
+                "type": "PKG-INFO",
+                "content": content
+            }));
+        }
+    }
+
+    // Try pyproject.toml
+    let pyproject_path = root.join("pyproject.toml");
+    if pyproject_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&pyproject_path) {
+            return Ok(serde_json::json!({
+                "type": "pyproject.toml",
+                "content": content
+            }));
+        }
+    }
+
+    // Try setup.py
+    let setup_path = root.join("setup.py");
+    if setup_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&setup_path) {
+            return Ok(serde_json::json!({
+                "type": "setup.py",
+                "content": content
+            }));
+        }
+    }
+
+    // Look in dist-info directory (for wheels)
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.ends_with(".dist-info") {
+                let metadata_path = entry.path().join("METADATA");
+                if metadata_path.exists() {
+                    if let Ok(content) = std::fs::read_to_string(&metadata_path) {
+                        return Ok(serde_json::json!({
+                            "type": "METADATA",
+                            "content": content
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(serde_json::json!({
+        "type": "unknown",
+        "content": ""
+    }))
+}
+
+/// Check if the package contains C extensions
+fn check_for_c_extensions(root: &Path) -> bool {
+    fn check_dir(dir: &Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            // Skip hidden and common non-source directories
+            if name_str.starts_with('.') || name_str == "__pycache__" {
+                continue;
+            }
+
+            if path.is_dir() {
+                if check_dir(&path) {
+                    return true;
+                }
+            } else if path.is_file() {
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if matches!(ext, "c" | "cpp" | "cxx" | "h" | "hpp" | "so" | "pyd") {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    check_dir(root)
+}
+
+/// Check if the package contains Cython files
+fn check_for_cython(root: &Path) -> bool {
+    fn check_dir(dir: &Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            if name_str.starts_with('.') || name_str == "__pycache__" {
+                continue;
+            }
+
+            if path.is_dir() {
+                if check_dir(&path) {
+                    return true;
+                }
+            } else if path.is_file() {
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if matches!(ext, "pyx" | "pxd") {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    check_dir(root)
+}
+
+/// Collect Python source files from the package
+fn collect_python_source_files(root: &Path) -> Result<Vec<PythonSourceFile>> {
+    let mut files = Vec::new();
+
+    fn visit_dir(dir: &Path, files: &mut Vec<PythonSourceFile>, base: &Path) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            // Skip hidden directories, __pycache__, egg-info, dist-info
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with('.')
+                    || name == "__pycache__"
+                    || name.ends_with(".egg-info")
+                    || name.ends_with(".dist-info")
+                    || name == "venv"
+                    || name == ".venv"
+                    || name == "node_modules"
+                {
+                    continue;
+                }
+            }
+
+            if path.is_dir() {
+                visit_dir(&path, files, base);
+            } else if path.is_file() {
+                // Check if it's a Python file
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if matches!(ext, "py" | "pyi") {
+                    // Read file (limit size to avoid huge files)
+                    if let Ok(metadata) = std::fs::metadata(&path) {
+                        if metadata.len() < 1_000_000 {
+                            // 1MB limit
+                            if let Ok(content) = std::fs::read_to_string(&path) {
+                                let relative_path = path
+                                    .strip_prefix(base)
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_else(|_| path.to_string_lossy().to_string());
+
+                                files.push(PythonSourceFile {
+                                    path: relative_path,
+                                    content,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    visit_dir(root, &mut files, root);
+
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_package_name() {
+        assert_eq!(normalize_package_name("Flask"), "flask");
+        assert_eq!(normalize_package_name("my_package"), "my-package");
+        assert_eq!(normalize_package_name("My_Package"), "my-package");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires network
+    async fn test_fetch_metadata() {
+        let client = PypiClient::new();
+        let metadata = client.fetch_metadata("requests").await.unwrap();
+
+        assert_eq!(metadata.name.to_lowercase(), "requests");
+        assert!(metadata.summary.is_some());
+    }
+}


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

- Add PypiClient for fetching metadata and downloading packages from PyPI
- Support both sdist (.tar.gz) and wheel (.whl) formats
- Add Python-specific capability detection (requests, subprocess, os.environ, etc.)
- Update CVE scanner to support PyPI ecosystem via OSV API
- Add Python dependency file parsing (requirements.txt, pyproject.toml, Pipfile)
- Update worker to dispatch scans based on registry type
- Add PyPI metadata structs (PypiPackageMetadata, PypiReleaseInfo, PypiMaintainer)
- Calculate trust score based on PyPI-specific signals (author, classifiers, etc.)

## Why

<!-- Why is this needed? -->

Support PyPi registry

Fixes #9 

## Test plan

- [x] Tests pass locally
- [x] Tested manually
