### PR TITLE
feat: add latest query param to group search results

### DIFF
--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -29,8 +29,16 @@ pub async fn list_packages(
     let limit = params.limit.unwrap_or(50).min(100); // Default 50, max 100
     let offset = params.offset.unwrap_or(0);
 
+    let latest = params.latest.unwrap_or(false);
+
     let (packages, total) = if let Some(ref q) = params.q {
-        state.db.search_packages(q, limit, offset).await
+        if latest {
+            state.db.search_packages_latest(q, limit, offset).await
+        } else {
+            state.db.search_packages(q, limit, offset).await
+        }
+    } else if latest {
+        state.db.get_packages_paginated_latest(limit, offset).await
     } else {
         state.db.get_packages_paginated(limit, offset).await
     }

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -386,6 +386,96 @@ impl Database {
 
         Ok((packages, total.0))
     }
+
+    /// Get packages with pagination, latest version only per (name, registry)
+    pub async fn get_packages_paginated_latest(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<(Vec<PackageWithCounts>, i64)> {
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            WITH latest AS (
+                SELECT DISTINCT ON (name, registry) *
+                FROM packages
+                ORDER BY name, registry, scanned_at DESC
+            )
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+            FROM latest p
+            ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        // Count unique packages (distinct name + registry combinations)
+        let total: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages) t",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok((packages, total.0))
+    }
+
+    /// Search packages by name, latest version only per (name, registry)
+    pub async fn search_packages_latest(
+        &self,
+        query: &str,
+        limit: i64,
+        offset: i64,
+    ) -> Result<(Vec<PackageWithCounts>, i64)> {
+        let pattern = format!("%{}%", query);
+
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            WITH latest AS (
+                SELECT DISTINCT ON (name, registry) *
+                FROM packages
+                WHERE name ILIKE $1
+                ORDER BY name, registry, scanned_at DESC
+            )
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+            FROM latest p
+            ORDER BY 
+                CASE 
+                    WHEN LOWER(p.name) = LOWER($2) THEN 0
+                    WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
+                    ELSE 2
+                END,
+                p.weekly_downloads DESC NULLS LAST,
+                p.name ASC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(&pattern)
+        .bind(query)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        // Count unique matching packages
+        let total: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages WHERE name ILIKE $1) t",
+        )
+        .bind(&pattern)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok((packages, total.0))
+    }
 }
 
 /// Package with CVE/threat counts for list views

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -416,11 +416,10 @@ impl Database {
         .await?;
 
         // Count unique packages (distinct name + registry combinations)
-        let total: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages) t",
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let total: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages) t")
+                .fetch_one(&self.pool)
+                .await?;
 
         Ok((packages, total.0))
     }

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -395,8 +395,8 @@ pub struct PackageListResponse {
 pub struct PaginationParams {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
-    pub q: Option<String>,      // Search query
-    pub latest: Option<bool>,   // If true, return only latest version per package
+    pub q: Option<String>,    // Search query
+    pub latest: Option<bool>, // If true, return only latest version per package
 }
 
 /// Full package response for API

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -395,7 +395,8 @@ pub struct PackageListResponse {
 pub struct PaginationParams {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
-    pub q: Option<String>, // Search query
+    pub q: Option<String>,      // Search query
+    pub latest: Option<bool>,   // If true, return only latest version per package
 }
 
 /// Full package response for API


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

Add `?latest=true` parameter to /v1/packages endpoint to return only the latest version per package (grouped by name + registry).

- Add latest field to PaginationParams
- Add get_packages_paginated_latest and search_packages_latest db methods
- Update list_packages handler to check latest param

## Why

<!-- Why is this needed? -->

Cleaner search results. 

## Test plan

- [x] Tests pass locally
- [x] Tested manually
