### PR TITLE
feat: add threat verification system and cautious CLI wording

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["sus contributors"]
 license = "MIT"

--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -181,6 +181,7 @@ pub async fn get_package(
                 confidence: t.confidence,
                 location: t.location,
                 snippet: t.snippet,
+                verification_status: t.verification_status,
             })
             .collect(),
         capabilities,
@@ -277,6 +278,7 @@ pub async fn get_package_version(
                 confidence: t.confidence,
                 location: t.location,
                 snippet: t.snippet,
+                verification_status: t.verification_status,
             })
             .collect(),
         capabilities,
@@ -381,6 +383,7 @@ pub async fn bulk_lookup(
                     confidence: t.confidence,
                     location: t.location,
                     snippet: t.snippet,
+                    verification_status: t.verification_status,
                 })
                 .collect(),
             capabilities,

--- a/crates/cli/src/ui.rs
+++ b/crates/cli/src/ui.rs
@@ -158,50 +158,56 @@ fn print_critical_assessment(assessment: &PackageResponse) {
     // Show the most critical issues first
     let mut items: Vec<String> = Vec::new();
 
-    // Malware/threats first
+    // Possible threats first (language chosen to be factual, not accusatory)
     for threat in &assessment.agentic_threats {
         if threat.confidence > 0.8 {
             let threat_desc = match threat.threat_type {
                 // LLM Safety
-                common::ThreatType::PromptInjection => "prompt injection attack",
-                common::ThreatType::ImproperOutputHandling => "improper output handling",
-                common::ThreatType::InsecureToolUsage => "insecure tool usage",
-                common::ThreatType::InstructionOverride => "instruction override attack",
+                common::ThreatType::PromptInjection => "patterns consistent with prompt injection",
+                common::ThreatType::ImproperOutputHandling => {
+                    "patterns consistent with improper output handling"
+                }
+                common::ThreatType::InsecureToolUsage => {
+                    "patterns consistent with insecure tool usage"
+                }
+                common::ThreatType::InstructionOverride => {
+                    "patterns consistent with instruction override"
+                }
                 // Secrets
-                common::ThreatType::HardcodedSecrets => "hardcoded secrets",
+                common::ThreatType::HardcodedSecrets => "possible hardcoded secrets",
                 // Data Handling
-                common::ThreatType::WeakCrypto => "weak cryptography",
-                common::ThreatType::SensitiveDataLogging => "sensitive data logging",
-                common::ThreatType::PiiViolations => "PII violations",
-                common::ThreatType::InsecureDeserialization => "insecure deserialization",
+                common::ThreatType::WeakCrypto => "possible weak cryptography",
+                common::ThreatType::SensitiveDataLogging => "possible sensitive data logging",
+                common::ThreatType::PiiViolations => "possible PII handling concerns",
+                common::ThreatType::InsecureDeserialization => "possible insecure deserialization",
                 // Injection
-                common::ThreatType::Xss => "XSS vulnerability",
-                common::ThreatType::Sqli => "SQL injection",
-                common::ThreatType::CommandInjection => "command injection",
-                common::ThreatType::Ssrf => "SSRF vulnerability",
-                common::ThreatType::Ssti => "SSTI vulnerability",
-                common::ThreatType::CodeInjection => "code injection",
+                common::ThreatType::Xss => "possible XSS vulnerability",
+                common::ThreatType::Sqli => "possible SQL injection",
+                common::ThreatType::CommandInjection => "possible command injection",
+                common::ThreatType::Ssrf => "possible SSRF vulnerability",
+                common::ThreatType::Ssti => "possible SSTI vulnerability",
+                common::ThreatType::CodeInjection => "possible code injection",
                 // Auth
-                common::ThreatType::AuthBypass => "authentication bypass",
-                common::ThreatType::WeakSessionTokens => "weak session tokens",
-                common::ThreatType::InsecurePasswordReset => "insecure password reset",
+                common::ThreatType::AuthBypass => "possible authentication bypass",
+                common::ThreatType::WeakSessionTokens => "possible weak session tokens",
+                common::ThreatType::InsecurePasswordReset => "possible insecure password reset",
                 // Supply Chain
-                common::ThreatType::MaliciousInstallScripts => "malicious install script",
-                common::ThreatType::DependencyConfusion => "dependency confusion",
-                common::ThreatType::Typosquatting => "typosquatting",
-                common::ThreatType::ObfuscatedCode => "obfuscated code",
+                common::ThreatType::MaliciousInstallScripts => "suspicious install script",
+                common::ThreatType::DependencyConfusion => "possible dependency confusion",
+                common::ThreatType::Typosquatting => "possible typosquatting",
+                common::ThreatType::ObfuscatedCode => "obfuscated code detected",
                 // Other
-                common::ThreatType::PathTraversal => "path traversal",
-                common::ThreatType::PrototypePollution => "prototype pollution",
-                common::ThreatType::Backdoor => "backdoor detected",
-                common::ThreatType::CryptoMiner => "crypto miner",
-                common::ThreatType::DataExfiltration => "data exfiltration attempt",
-                common::ThreatType::SocialEngineering => "social engineering attack",
+                common::ThreatType::PathTraversal => "possible path traversal",
+                common::ThreatType::PrototypePollution => "possible prototype pollution",
+                common::ThreatType::Backdoor => "suspicious backdoor-like patterns",
+                common::ThreatType::CryptoMiner => "possible crypto mining code",
+                common::ThreatType::DataExfiltration => "possible data exfiltration patterns",
+                common::ThreatType::SocialEngineering => "possible social engineering indicators",
                 // Legacy
-                common::ThreatType::InstallScriptInjection => "malicious install script",
-                common::ThreatType::MaliciousCode => "malware detected",
+                common::ThreatType::InstallScriptInjection => "suspicious install script",
+                common::ThreatType::MaliciousCode => "suspicious code patterns",
             };
-            items.push(format!("{}: {}", "threat".red(), threat_desc));
+            items.push(format!("{}: {}", "possible threat".red(), threat_desc));
         }
     }
 
@@ -219,13 +225,13 @@ fn print_critical_assessment(assessment: &PackageResponse) {
         }
     }
 
-    // Add status if known malware
+    // Add status if suspicious patterns detected
     if assessment
         .risk_reasons
         .iter()
         .any(|r| r.to_lowercase().contains("malware") || r.to_lowercase().contains("malicious"))
     {
-        items.push("status: COMPROMISED".to_string());
+        items.push("status: requires review".to_string());
     }
 
     // Print items in tree format

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -125,12 +125,12 @@ impl Database {
         Ok(cves)
     }
 
-    /// Get agentic threats for a package
+    /// Get verified agentic threats for a package (only verified threats are returned)
     pub async fn get_package_threats(&self, package_id: i32) -> Result<Vec<AgenticThreat>> {
         let threats = sqlx::query_as::<_, AgenticThreat>(
             r#"
             SELECT * FROM agentic_threats 
-            WHERE package_id = $1
+            WHERE package_id = $1 AND verification_status = 'verified'
             "#,
         )
         .bind(package_id)
@@ -353,7 +353,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM packages p
                 WHERE p.registry = $3
                 ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
@@ -379,7 +379,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM packages p
                 ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
                 LIMIT $1 OFFSET $2
@@ -418,7 +418,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM packages p
                 WHERE p.name ILIKE $1 AND p.registry = $5
                 ORDER BY 
@@ -456,7 +456,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM packages p
                 WHERE p.name ILIKE $1
                 ORDER BY 
@@ -508,7 +508,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM latest p
                 ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
                 LIMIT $1 OFFSET $2
@@ -540,7 +540,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM latest p
                 ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
                 LIMIT $1 OFFSET $2
@@ -586,7 +586,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM latest p
                 ORDER BY 
                     CASE 
@@ -629,7 +629,7 @@ impl Database {
                     p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
                     p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
                     COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id), 0) as threat_count
+                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
                 FROM latest p
                 ORDER BY 
                     CASE 

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -100,6 +100,18 @@ pub enum Registry {
     Crates,
 }
 
+/// Verification status for agentic threats
+/// Only verified threats affect risk_level and are shown to CLI users
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type, Default)]
+#[sqlx(type_name = "varchar", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Verified,
+}
+
 impl Registry {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -160,6 +172,8 @@ pub struct AgenticThreat {
     pub location: Option<String>,
     pub snippet: Option<String>,
     pub detected_at: DateTime<Utc>,
+    /// Verification status - only verified threats affect risk_level
+    pub verification_status: VerificationStatus,
 }
 
 /// Network capabilities of a package
@@ -322,6 +336,8 @@ pub struct AgenticThreatSummary {
     pub confidence: f32,
     pub location: Option<String>,
     pub snippet: Option<String>,
+    /// Verification status - only verified threats affect risk_level
+    pub verification_status: VerificationStatus,
 }
 
 /// Publisher information

--- a/crates/worker/src/scanner/agentic.rs
+++ b/crates/worker/src/scanner/agentic.rs
@@ -3,7 +3,7 @@
 
 use crate::registry::ExtractedPackage;
 use anyhow::{Context, Result};
-use common::{AgenticThreatSummary, ApiDoc, ThreatType, UsageDocs};
+use common::{AgenticThreatSummary, ApiDoc, ThreatType, UsageDocs, VerificationStatus};
 use serde::Deserialize;
 use std::path::Path;
 use std::process::Stdio;
@@ -257,7 +257,7 @@ If no threats: {"threats": [], "summary": "No security concerns detected"}"#;
         // Parse the JSON output
         let report: OpenCodeThreatReport = self.parse_json_output(&output)?;
 
-        // Convert to AgenticThreatSummary
+        // Convert to AgenticThreatSummary (all new threats start as Pending)
         let threats: Vec<AgenticThreatSummary> = report
             .threats
             .into_iter()
@@ -267,6 +267,7 @@ If no threats: {"threats": [], "summary": "No security concerns detected"}"#;
                 confidence: t.confidence.unwrap_or(0.7),
                 location: t.location,
                 snippet: t.snippet,
+                verification_status: VerificationStatus::Pending,
             })
             .collect();
 
@@ -504,6 +505,7 @@ If no threats verified: {{"threats": [], "summary": "No security concerns confir
         let report: OpenCodeThreatReport = self.parse_json_output(&output)?;
 
         // Convert to AgenticThreatSummary (no confidence filtering on verification)
+        // These are still Pending - human review is required to change to Verified
         let verified_threats: Vec<AgenticThreatSummary> = report
             .threats
             .into_iter()
@@ -512,6 +514,7 @@ If no threats verified: {{"threats": [], "summary": "No security concerns confir
                 confidence: t.confidence.unwrap_or(0.8), // Higher default for verified threats
                 location: t.location,
                 snippet: t.snippet,
+                verification_status: VerificationStatus::Pending,
             })
             .collect();
 

--- a/crates/worker/src/scanner/mod.rs
+++ b/crates/worker/src/scanner/mod.rs
@@ -11,7 +11,7 @@ use capabilities::CapabilityExtractor;
 use common::{
     db::{NewAgenticThreat, NewPackage, NewPackageCve},
     AgenticThreatSummary, CveSummary, Database, NpmPackageMetadata, PackageCapabilities,
-    PypiPackageMetadata, Registry, RiskLevel, UsageDocs,
+    PypiPackageMetadata, Registry, RiskLevel, UsageDocs, VerificationStatus,
 };
 use cve::CveScanner;
 use std::sync::Arc;
@@ -95,12 +95,11 @@ pub fn calculate_trust_score_unified(metadata: Option<&PackageMetadata>) -> u8 {
     score.min(100)
 }
 
-/// Calculate risk level and reasons based on CVEs, threats, capabilities, and trust score
+/// Calculate risk level and reasons based on CVEs and verified agentic threats only.
+/// Capabilities and trust score are informational and do not affect risk level.
 pub fn calculate_risk(
     cves: &[CveSummary],
     agentic_threats: &[AgenticThreatSummary],
-    capabilities: &PackageCapabilities,
-    trust_score: u8,
 ) -> (RiskLevel, Vec<String>) {
     let mut reasons = Vec::new();
     let mut max_level = RiskLevel::Clean;
@@ -125,8 +124,12 @@ pub fn calculate_risk(
         }
     }
 
-    // Check agentic threats (use cautious language - these are automated assessments)
-    for threat in agentic_threats {
+    // Check agentic threats - only VERIFIED threats affect risk level
+    // (use cautious language - these are automated assessments that have been human-verified)
+    for threat in agentic_threats
+        .iter()
+        .filter(|t| t.verification_status == VerificationStatus::Verified)
+    {
         if threat.confidence > 0.8 {
             reasons.push(format!(
                 "Detected patterns consistent with {:?} ({}% confidence)",
@@ -146,28 +149,8 @@ pub fn calculate_risk(
         }
     }
 
-    // Check risky capabilities (factual observations, not judgments)
-    if capabilities.native.has_native {
-        reasons.push("Package includes native code modules".to_string());
-        if max_level == RiskLevel::Clean {
-            max_level = RiskLevel::Warning;
-        }
-    }
-
-    if capabilities.process.spawns_children {
-        reasons.push("Package can spawn child processes".to_string());
-        if max_level == RiskLevel::Clean {
-            max_level = RiskLevel::Warning;
-        }
-    }
-
-    // Low trust score
-    if trust_score < 30 {
-        reasons.push(format!("Low trust score assessed ({})", trust_score));
-        if max_level == RiskLevel::Clean {
-            max_level = RiskLevel::Warning;
-        }
-    }
+    // Note: Capabilities (native code, child processes) and trust score are informational only
+    // and do not affect risk_level. Only CVEs and verified agentic threats determine risk.
 
     (max_level, reasons)
 }
@@ -523,9 +506,8 @@ impl PackageScanner {
         // Calculate trust score using adapter
         let trust_score = adapter.compute_trust_score(metadata);
 
-        // Determine risk level
-        let (risk_level, risk_reasons) =
-            calculate_risk(&cves, &agentic_threats, &capabilities, trust_score);
+        // Determine risk level (based on CVEs and verified agentic threats only)
+        let (risk_level, risk_reasons) = calculate_risk(&cves, &agentic_threats);
 
         // Generate SKILL.md
         let skill_md = generate_skill_md(
@@ -792,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_risk_clean_package() {
-        let (level, reasons) = calculate_risk(&[], &[], &PackageCapabilities::default(), 75);
+        let (level, reasons) = calculate_risk(&[], &[]);
         assert_eq!(level, RiskLevel::Clean);
         assert!(reasons.is_empty());
     }
@@ -805,7 +787,7 @@ mod tests {
             description: Some("Bad vulnerability".to_string()),
             fixed_in: Some("2.0.0".to_string()),
         }];
-        let (level, reasons) = calculate_risk(&cves, &[], &PackageCapabilities::default(), 75);
+        let (level, reasons) = calculate_risk(&cves, &[]);
         assert_eq!(level, RiskLevel::Critical);
         assert!(reasons.iter().any(|r| r.contains("CVE-2024-1234")));
     }
@@ -818,7 +800,7 @@ mod tests {
             description: None,
             fixed_in: None,
         }];
-        let (level, _) = calculate_risk(&cves, &[], &PackageCapabilities::default(), 75);
+        let (level, _) = calculate_risk(&cves, &[]);
         assert_eq!(
             level,
             RiskLevel::Critical,
@@ -834,7 +816,7 @@ mod tests {
             description: None,
             fixed_in: None,
         }];
-        let (level, _) = calculate_risk(&cves, &[], &PackageCapabilities::default(), 75);
+        let (level, _) = calculate_risk(&cves, &[]);
         assert_eq!(
             level,
             RiskLevel::Warning,
@@ -849,8 +831,9 @@ mod tests {
             confidence: 0.9,
             location: Some("README.md".to_string()),
             snippet: Some("ignore previous instructions".to_string()),
+            verification_status: VerificationStatus::Verified,
         }];
-        let (level, reasons) = calculate_risk(&[], &threats, &PackageCapabilities::default(), 75);
+        let (level, reasons) = calculate_risk(&[], &threats);
         assert_eq!(level, RiskLevel::Critical);
         assert!(reasons.iter().any(|r| r.contains("PromptInjection")));
         assert!(reasons
@@ -865,21 +848,24 @@ mod tests {
             confidence: 0.6,
             location: None,
             snippet: None,
+            verification_status: VerificationStatus::Verified,
         }];
-        let (level, reasons) = calculate_risk(&[], &threats, &PackageCapabilities::default(), 75);
+        let (level, reasons) = calculate_risk(&[], &threats);
         assert_eq!(level, RiskLevel::Warning);
         assert!(reasons.iter().any(|r| r.contains("Flagged for potential")));
     }
 
     #[test]
     fn test_risk_low_confidence_threat_ignored() {
+        // Even verified threats with low confidence should be ignored
         let threats = vec![AgenticThreatSummary {
             threat_type: ThreatType::SocialEngineering,
             confidence: 0.3,
             location: None,
             snippet: None,
+            verification_status: VerificationStatus::Verified,
         }];
-        let (level, reasons) = calculate_risk(&[], &threats, &PackageCapabilities::default(), 75);
+        let (level, reasons) = calculate_risk(&[], &threats);
         assert_eq!(
             level,
             RiskLevel::Clean,
@@ -889,32 +875,22 @@ mod tests {
     }
 
     #[test]
-    fn test_risk_native_code() {
-        let mut capabilities = PackageCapabilities::default();
-        capabilities.native.has_native = true;
-        let (level, reasons) = calculate_risk(&[], &[], &capabilities, 75);
-        assert_eq!(level, RiskLevel::Warning);
-        assert!(reasons.iter().any(|r| r.contains("native code")));
-    }
-
-    #[test]
-    fn test_risk_spawns_children() {
-        let mut capabilities = PackageCapabilities::default();
-        capabilities.process.spawns_children = true;
-        let (level, reasons) = calculate_risk(&[], &[], &capabilities, 75);
-        assert_eq!(level, RiskLevel::Warning);
-        assert!(reasons
-            .iter()
-            .any(|r| r.contains("can spawn child processes")));
-    }
-
-    #[test]
-    fn test_risk_low_trust_score() {
-        let (level, reasons) = calculate_risk(&[], &[], &PackageCapabilities::default(), 25);
-        assert_eq!(level, RiskLevel::Warning);
-        assert!(reasons
-            .iter()
-            .any(|r| r.contains("Low trust score assessed")));
+    fn test_risk_unverified_threat_ignored() {
+        // Unverified threats should not affect risk level regardless of confidence
+        let threats = vec![AgenticThreatSummary {
+            threat_type: ThreatType::PromptInjection,
+            confidence: 0.95,
+            location: Some("README.md".to_string()),
+            snippet: Some("ignore previous instructions".to_string()),
+            verification_status: VerificationStatus::Pending,
+        }];
+        let (level, reasons) = calculate_risk(&[], &threats);
+        assert_eq!(
+            level,
+            RiskLevel::Clean,
+            "Unverified threats should not affect risk level"
+        );
+        assert!(reasons.is_empty());
     }
 
     #[test]
@@ -933,7 +909,7 @@ mod tests {
                 fixed_in: None,
             },
         ];
-        let (level, _) = calculate_risk(&cves, &[], &PackageCapabilities::default(), 75);
+        let (level, _) = calculate_risk(&cves, &[]);
         assert_eq!(
             level,
             RiskLevel::Critical,

--- a/migrations/20260205000000_add_threat_verification.sql
+++ b/migrations/20260205000000_add_threat_verification.sql
@@ -1,0 +1,14 @@
+-- Add verification status column to agentic_threats
+-- Three states: pending (default), in_progress, verified
+-- Only verified threats affect risk_level and are shown to CLI users
+
+ALTER TABLE agentic_threats 
+ADD COLUMN verification_status VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+-- Add constraint for valid values
+ALTER TABLE agentic_threats
+ADD CONSTRAINT chk_verification_status 
+CHECK (verification_status IN ('pending', 'in_progress', 'verified'));
+
+-- Index for filtering by status
+CREATE INDEX idx_agentic_threats_status ON agentic_threats(verification_status);


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

- Add verification_status column to agentic_threats (pending/in_progress/verified)
- Only verified threats affect risk_level and are shown to CLI users
- Update CLI wording to use "possible threat" and factual language
- Risk calculation now based only on CVEs and verified agentic threats
- Bump version to 0.1.8

## Why

<!-- Why is this needed? -->

- Adds human-in-the-loop verification step
- Reduces false positives

## Test plan

- [x] Tests pass locally
- [x] Tested manually
