### PR TITLE
feat: add risk_level filter to packages API

### DIFF
--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -30,26 +30,30 @@ pub async fn list_packages(
     let offset = params.offset.unwrap_or(0);
 
     let latest = params.latest.unwrap_or(false);
-    let registry = params.registry.as_deref();
+    let registry = params.registry;
+    let risk_level = params.risk_level;
 
     let (packages, total) = if let Some(ref q) = params.q {
         if latest {
             state
                 .db
-                .search_packages_latest(q, limit, offset, registry)
+                .search_packages_latest(q, limit, offset, registry, risk_level)
                 .await
         } else {
-            state.db.search_packages(q, limit, offset, registry).await
+            state
+                .db
+                .search_packages(q, limit, offset, registry, risk_level)
+                .await
         }
     } else if latest {
         state
             .db
-            .get_packages_paginated_latest(limit, offset, registry)
+            .get_packages_paginated_latest(limit, offset, registry, risk_level)
             .await
     } else {
         state
             .db
-            .get_packages_paginated(limit, offset, registry)
+            .get_packages_paginated(limit, offset, registry, risk_level)
             .await
     }
     .map_err(|e| {

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -344,60 +344,46 @@ impl Database {
         &self,
         limit: i64,
         offset: i64,
-        registry: Option<&str>,
+        registry: Option<Registry>,
+        risk_level: Option<RiskLevel>,
     ) -> Result<(Vec<PackageWithCounts>, i64)> {
-        let (packages, total) = if let Some(reg) = registry {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM packages p
-                WHERE p.registry = $3
-                ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
-                LIMIT $1 OFFSET $2
-                "#,
-            )
-            .bind(limit)
-            .bind(offset)
-            .bind(reg)
-            .fetch_all(&self.pool)
-            .await?;
+        let registry_str = registry.map(|r| r.to_string());
+        let risk_level_str = risk_level.map(|r| r.to_string());
 
-            let total: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM packages WHERE registry = $1")
-                .bind(reg)
-                .fetch_one(&self.pool)
-                .await?;
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
+            FROM packages p
+            WHERE ($3::text IS NULL OR p.registry = $3)
+              AND ($4::text IS NULL OR p.risk_level = $4)
+            ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_all(&self.pool)
+        .await?;
 
-            (packages, total.0)
-        } else {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM packages p
-                ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
-                LIMIT $1 OFFSET $2
-                "#,
-            )
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
+        let total: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM packages
+            WHERE ($1::text IS NULL OR registry = $1)
+              AND ($2::text IS NULL OR risk_level = $2)
+            "#,
+        )
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_one(&self.pool)
+        .await?;
 
-            let total: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM packages")
-                .fetch_one(&self.pool)
-                .await?;
-
-            (packages, total.0)
-        };
-
-        Ok((packages, total))
+        Ok((packages, total.0))
     }
 
     /// Search packages by name with pagination and CVE/threat counts
@@ -407,85 +393,59 @@ impl Database {
         query: &str,
         limit: i64,
         offset: i64,
-        registry: Option<&str>,
+        registry: Option<Registry>,
+        risk_level: Option<RiskLevel>,
     ) -> Result<(Vec<PackageWithCounts>, i64)> {
         let pattern = format!("%{}%", query);
+        let registry_str = registry.map(|r| r.to_string());
+        let risk_level_str = risk_level.map(|r| r.to_string());
 
-        let (packages, total) = if let Some(reg) = registry {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM packages p
-                WHERE p.name ILIKE $1 AND p.registry = $5
-                ORDER BY 
-                    CASE 
-                        WHEN LOWER(p.name) = LOWER($2) THEN 0
-                        WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
-                        ELSE 2
-                    END,
-                    p.weekly_downloads DESC NULLS LAST,
-                    p.name ASC
-                LIMIT $3 OFFSET $4
-                "#,
-            )
-            .bind(&pattern)
-            .bind(query)
-            .bind(limit)
-            .bind(offset)
-            .bind(reg)
-            .fetch_all(&self.pool)
-            .await?;
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
+            FROM packages p
+            WHERE p.name ILIKE $1
+              AND ($5::text IS NULL OR p.registry = $5)
+              AND ($6::text IS NULL OR p.risk_level = $6)
+            ORDER BY 
+                CASE 
+                    WHEN LOWER(p.name) = LOWER($2) THEN 0
+                    WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
+                    ELSE 2
+                END,
+                p.weekly_downloads DESC NULLS LAST,
+                p.name ASC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(&pattern)
+        .bind(query)
+        .bind(limit)
+        .bind(offset)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_all(&self.pool)
+        .await?;
 
-            let total: (i64,) = sqlx::query_as(
-                "SELECT COUNT(*) FROM packages WHERE name ILIKE $1 AND registry = $2",
-            )
-            .bind(&pattern)
-            .bind(reg)
-            .fetch_one(&self.pool)
-            .await?;
+        let total: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM packages
+            WHERE name ILIKE $1
+              AND ($2::text IS NULL OR registry = $2)
+              AND ($3::text IS NULL OR risk_level = $3)
+            "#,
+        )
+        .bind(&pattern)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_one(&self.pool)
+        .await?;
 
-            (packages, total.0)
-        } else {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM packages p
-                WHERE p.name ILIKE $1
-                ORDER BY 
-                    CASE 
-                        WHEN LOWER(p.name) = LOWER($2) THEN 0
-                        WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
-                        ELSE 2
-                    END,
-                    p.weekly_downloads DESC NULLS LAST,
-                    p.name ASC
-                LIMIT $3 OFFSET $4
-                "#,
-            )
-            .bind(&pattern)
-            .bind(query)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-
-            let total: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM packages WHERE name ILIKE $1")
-                .bind(&pattern)
-                .fetch_one(&self.pool)
-                .await?;
-
-            (packages, total.0)
-        };
-
-        Ok((packages, total))
+        Ok((packages, total.0))
     }
 
     /// Get packages with pagination, latest version only per (name, registry)
@@ -493,74 +453,53 @@ impl Database {
         &self,
         limit: i64,
         offset: i64,
-        registry: Option<&str>,
+        registry: Option<Registry>,
+        risk_level: Option<RiskLevel>,
     ) -> Result<(Vec<PackageWithCounts>, i64)> {
-        let (packages, total) = if let Some(reg) = registry {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                WITH latest AS (
-                    SELECT DISTINCT ON (name, registry) *
-                    FROM packages
-                    WHERE registry = $3
-                    ORDER BY name, registry, scanned_at DESC
-                )
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM latest p
-                ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
-                LIMIT $1 OFFSET $2
-                "#,
+        let registry_str = registry.map(|r| r.to_string());
+        let risk_level_str = risk_level.map(|r| r.to_string());
+
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            WITH latest AS (
+                SELECT DISTINCT ON (name, registry) *
+                FROM packages
+                WHERE ($3::text IS NULL OR registry = $3)
+                  AND ($4::text IS NULL OR risk_level = $4)
+                ORDER BY name, registry, scanned_at DESC
             )
-            .bind(limit)
-            .bind(offset)
-            .bind(reg)
-            .fetch_all(&self.pool)
-            .await?;
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
+            FROM latest p
+            ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_all(&self.pool)
+        .await?;
 
-            let total: (i64,) = sqlx::query_as(
-                "SELECT COUNT(*) FROM (SELECT DISTINCT name FROM packages WHERE registry = $1) t",
-            )
-            .bind(reg)
-            .fetch_one(&self.pool)
-            .await?;
+        let total: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM (
+                SELECT DISTINCT name, registry FROM packages
+                WHERE ($1::text IS NULL OR registry = $1)
+                  AND ($2::text IS NULL OR risk_level = $2)
+            ) t
+            "#,
+        )
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_one(&self.pool)
+        .await?;
 
-            (packages, total.0)
-        } else {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                WITH latest AS (
-                    SELECT DISTINCT ON (name, registry) *
-                    FROM packages
-                    ORDER BY name, registry, scanned_at DESC
-                )
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM latest p
-                ORDER BY p.weekly_downloads DESC NULLS LAST, p.name ASC
-                LIMIT $1 OFFSET $2
-                "#,
-            )
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-
-            let total: (i64,) = sqlx::query_as(
-                "SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages) t",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-
-            (packages, total.0)
-        };
-
-        Ok((packages, total))
+        Ok((packages, total.0))
     }
 
     /// Search packages by name, latest version only per (name, registry)
@@ -569,97 +508,66 @@ impl Database {
         query: &str,
         limit: i64,
         offset: i64,
-        registry: Option<&str>,
+        registry: Option<Registry>,
+        risk_level: Option<RiskLevel>,
     ) -> Result<(Vec<PackageWithCounts>, i64)> {
         let pattern = format!("%{}%", query);
+        let registry_str = registry.map(|r| r.to_string());
+        let risk_level_str = risk_level.map(|r| r.to_string());
 
-        let (packages, total) = if let Some(reg) = registry {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                WITH latest AS (
-                    SELECT DISTINCT ON (name, registry) *
-                    FROM packages
-                    WHERE name ILIKE $1 AND registry = $5
-                    ORDER BY name, registry, scanned_at DESC
-                )
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM latest p
-                ORDER BY 
-                    CASE 
-                        WHEN LOWER(p.name) = LOWER($2) THEN 0
-                        WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
-                        ELSE 2
-                    END,
-                    p.weekly_downloads DESC NULLS LAST,
-                    p.name ASC
-                LIMIT $3 OFFSET $4
-                "#,
+        let packages: Vec<PackageWithCounts> = sqlx::query_as(
+            r#"
+            WITH latest AS (
+                SELECT DISTINCT ON (name, registry) *
+                FROM packages
+                WHERE name ILIKE $1
+                  AND ($5::text IS NULL OR registry = $5)
+                  AND ($6::text IS NULL OR risk_level = $6)
+                ORDER BY name, registry, scanned_at DESC
             )
-            .bind(&pattern)
-            .bind(query)
-            .bind(limit)
-            .bind(offset)
-            .bind(reg)
-            .fetch_all(&self.pool)
-            .await?;
+            SELECT 
+                p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
+                p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
+                COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
+                COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
+            FROM latest p
+            ORDER BY 
+                CASE 
+                    WHEN LOWER(p.name) = LOWER($2) THEN 0
+                    WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
+                    ELSE 2
+                END,
+                p.weekly_downloads DESC NULLS LAST,
+                p.name ASC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(&pattern)
+        .bind(query)
+        .bind(limit)
+        .bind(offset)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_all(&self.pool)
+        .await?;
 
-            let total: (i64,) = sqlx::query_as(
-                "SELECT COUNT(*) FROM (SELECT DISTINCT name FROM packages WHERE name ILIKE $1 AND registry = $2) t",
-            )
-            .bind(&pattern)
-            .bind(reg)
-            .fetch_one(&self.pool)
-            .await?;
+        let total: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM (
+                SELECT DISTINCT name, registry FROM packages
+                WHERE name ILIKE $1
+                  AND ($2::text IS NULL OR registry = $2)
+                  AND ($3::text IS NULL OR risk_level = $3)
+            ) t
+            "#,
+        )
+        .bind(&pattern)
+        .bind(&registry_str)
+        .bind(&risk_level_str)
+        .fetch_one(&self.pool)
+        .await?;
 
-            (packages, total.0)
-        } else {
-            let packages: Vec<PackageWithCounts> = sqlx::query_as(
-                r#"
-                WITH latest AS (
-                    SELECT DISTINCT ON (name, registry) *
-                    FROM packages
-                    WHERE name ILIKE $1
-                    ORDER BY name, registry, scanned_at DESC
-                )
-                SELECT 
-                    p.id, p.name, p.version, p.registry, p.risk_level, p.trust_score,
-                    p.publisher_verified, p.weekly_downloads, p.capabilities, p.scanned_at,
-                    COALESCE((SELECT COUNT(*) FROM package_cves WHERE package_id = p.id), 0) as cve_count,
-                    COALESCE((SELECT COUNT(*) FROM agentic_threats WHERE package_id = p.id AND verification_status = 'verified'), 0) as threat_count
-                FROM latest p
-                ORDER BY 
-                    CASE 
-                        WHEN LOWER(p.name) = LOWER($2) THEN 0
-                        WHEN LOWER(p.name) LIKE LOWER($2) || '%' THEN 1
-                        ELSE 2
-                    END,
-                    p.weekly_downloads DESC NULLS LAST,
-                    p.name ASC
-                LIMIT $3 OFFSET $4
-                "#,
-            )
-            .bind(&pattern)
-            .bind(query)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-
-            let total: (i64,) = sqlx::query_as(
-                "SELECT COUNT(*) FROM (SELECT DISTINCT name, registry FROM packages WHERE name ILIKE $1) t",
-            )
-            .bind(&pattern)
-            .fetch_one(&self.pool)
-            .await?;
-
-            (packages, total.0)
-        };
-
-        Ok((packages, total))
+        Ok((packages, total.0))
     }
 }
 

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -433,10 +433,14 @@ pub struct PackageListResponse {
 pub struct PaginationParams {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
-    pub q: Option<String>,              // Search query
-    pub latest: Option<bool>,           // If true, return only latest version per package
-    pub registry: Option<Registry>,     // Filter by registry (npm, pypi, crates)
-    pub risk_level: Option<RiskLevel>,  // Filter by risk level (clean, warning, critical)
+    /// Search query
+    pub q: Option<String>,
+    /// If true, return only latest version per package
+    pub latest: Option<bool>,
+    /// Filter by registry (npm, pypi, crates)
+    pub registry: Option<Registry>,
+    /// Filter by risk level (clean, warning, critical)
+    pub risk_level: Option<RiskLevel>,
 }
 
 /// Full package response for API

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -24,6 +24,20 @@ impl RiskLevel {
             RiskLevel::Critical => "🚨",
         }
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RiskLevel::Clean => "clean",
+            RiskLevel::Warning => "warning",
+            RiskLevel::Critical => "critical",
+        }
+    }
+}
+
+impl std::fmt::Display for RiskLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 /// Types of security threats that can be detected
@@ -419,9 +433,10 @@ pub struct PackageListResponse {
 pub struct PaginationParams {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
-    pub q: Option<String>,        // Search query
-    pub latest: Option<bool>,     // If true, return only latest version per package
-    pub registry: Option<String>, // Filter by registry (npm, pypi)
+    pub q: Option<String>,              // Search query
+    pub latest: Option<bool>,           // If true, return only latest version per package
+    pub registry: Option<Registry>,     // Filter by registry (npm, pypi, crates)
+    pub risk_level: Option<RiskLevel>,  // Filter by risk level (clean, warning, critical)
 }
 
 /// Full package response for API


### PR DESCRIPTION
## Summary

- Add server-side filtering by `risk_level` (clean, warning, critical) to the `/v1/packages` endpoint
- This enables the frontend to query verified packages directly without client-side filtering after pagination

## Changes

- Add `risk_level` field to `PaginationParams`
- Update `PaginationParams.registry` from `String` to `Registry` enum
- Add `Display` impl for `RiskLevel` enum
- Update all 4 paginated DB methods to filter by `registry` and `risk_level`
- Simplify DB queries using optional WHERE clauses instead of if/else branching

## API Usage

```
GET /v1/packages?latest=true&registry=npm&risk_level=clean
```

| Parameter | Values | Description |
|-----------|--------|-------------|
| `registry` | `npm`, `pypi`, `crates` | Filter by package registry |
| `risk_level` | `clean`, `warning`, `critical` | Filter by risk level |

## Test plan

- [ ] Verify `/v1/packages?latest=true&registry=npm` returns only npm packages
- [ ] Verify `/v1/packages?latest=true&risk_level=clean` returns only clean packages
- [ ] Verify `/v1/packages?latest=true&registry=npm&risk_level=clean` combines both filters
- [ ] Verify `total` count reflects filtered results for correct pagination