### PR TITLE
feat: wire up install_scripts detection in scan pipeline

### DIFF
--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -8,9 +8,9 @@ use axum::{
     Json,
 };
 use common::{
-    AgenticThreatSummary, BulkLookupRequest, CveSummary, InstallScripts, MaintainerInfo,
-    PackageCapabilities, PackageListItem, PackageListResponse, PackageResponse, PaginationParams,
-    PublisherInfo, Registry, ScanJob, ScanPriority, ScanRequest, ScanRequestResponse,
+    AgenticThreatSummary, BulkLookupRequest, CveSummary, MaintainerInfo, PackageCapabilities,
+    PackageListItem, PackageListResponse, PackageResponse, PaginationParams, PublisherInfo,
+    Registry, ScanJob, ScanPriority, ScanRequest, ScanRequestResponse,
 };
 use serde_json::json;
 use std::io::Write;
@@ -168,7 +168,8 @@ pub async fn get_package(
         maintainers,
         maintainer_count: package.maintainer_count.map(|c| c as u32),
         last_publish: package.last_publish,
-        install_scripts: InstallScripts::default(), // TODO: store in DB
+        install_scripts: serde_json::from_value(package.install_scripts.clone())
+            .unwrap_or_default(),
         cves: cves
             .into_iter()
             .map(|c| CveSummary {
@@ -265,7 +266,8 @@ pub async fn get_package_version(
         maintainers,
         maintainer_count: package.maintainer_count.map(|c| c as u32),
         last_publish: package.last_publish,
-        install_scripts: InstallScripts::default(),
+        install_scripts: serde_json::from_value(package.install_scripts.clone())
+            .unwrap_or_default(),
         cves: cves
             .into_iter()
             .map(|c| CveSummary {
@@ -370,7 +372,8 @@ pub async fn bulk_lookup(
             maintainers,
             maintainer_count: package.maintainer_count.map(|c| c as u32),
             last_publish: package.last_publish,
-            install_scripts: InstallScripts::default(),
+            install_scripts: serde_json::from_value(package.install_scripts.clone())
+                .unwrap_or_default(),
             cves: cves
                 .into_iter()
                 .map(|c| CveSummary {

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -146,8 +146,8 @@ impl Database {
             r#"
             INSERT INTO packages (name, version, registry, risk_level, risk_reasons, trust_score, 
                 publisher_verified, weekly_downloads, maintainer_count, maintainers, last_publish, 
-                capabilities, skill_md, scan_version)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                capabilities, install_scripts, skill_md, scan_version)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             ON CONFLICT (name, version, registry) DO UPDATE SET
                 risk_level = EXCLUDED.risk_level,
                 risk_reasons = EXCLUDED.risk_reasons,
@@ -158,6 +158,7 @@ impl Database {
                 maintainers = EXCLUDED.maintainers,
                 last_publish = EXCLUDED.last_publish,
                 capabilities = EXCLUDED.capabilities,
+                install_scripts = EXCLUDED.install_scripts,
                 skill_md = EXCLUDED.skill_md,
                 scan_version = EXCLUDED.scan_version,
                 scanned_at = NOW()
@@ -176,6 +177,7 @@ impl Database {
         .bind(&package.maintainers)
         .bind(package.last_publish)
         .bind(&package.capabilities)
+        .bind(&package.install_scripts)
         .bind(&package.skill_md)
         .bind(&package.scan_version)
         .fetch_one(&self.pool)
@@ -329,7 +331,7 @@ impl Database {
             r#"
             SELECT id, name, version, registry, risk_level, risk_reasons, trust_score,
                    publisher_verified, weekly_downloads, maintainer_count,
-                   last_publish, capabilities, skill_md, scanned_at, scan_version
+                   last_publish, capabilities, install_scripts, skill_md, scanned_at, scan_version
             FROM packages
             ORDER BY name, version
             "#,
@@ -608,6 +610,7 @@ pub struct NewPackage {
     pub maintainers: Option<serde_json::Value>,
     pub last_publish: Option<chrono::DateTime<chrono::Utc>>,
     pub capabilities: serde_json::Value,
+    pub install_scripts: serde_json::Value,
     pub skill_md: Option<String>,
     pub scan_version: Option<String>,
 }

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -160,6 +160,7 @@ pub struct Package {
     pub maintainer_count: Option<i32>,
     pub last_publish: Option<DateTime<Utc>>,
     pub capabilities: serde_json::Value,
+    pub install_scripts: serde_json::Value,
     /// Maintainers list as JSON array
     pub maintainers: Option<serde_json::Value>,
     pub skill_md: Option<String>,

--- a/crates/worker/src/scanner/mod.rs
+++ b/crates/worker/src/scanner/mod.rs
@@ -10,8 +10,9 @@ use anyhow::Result;
 use capabilities::CapabilityExtractor;
 use common::{
     db::{NewAgenticThreat, NewPackage, NewPackageCve},
-    AgenticThreatSummary, CveSummary, Database, NpmPackageMetadata, PackageCapabilities,
-    PypiPackageMetadata, Registry, RiskLevel, ThreatType, UsageDocs, VerificationStatus,
+    AgenticThreatSummary, CveSummary, Database, InstallScripts, NpmPackageMetadata,
+    PackageCapabilities, PypiPackageMetadata, Registry, RiskLevel, ThreatType, UsageDocs,
+    VerificationStatus,
 };
 use cve::CveScanner;
 use std::sync::Arc;
@@ -404,6 +405,40 @@ fn extract_referenced_skills(extracted: &ExtractedPackage) -> Vec<String> {
     skills
 }
 
+/// Detect lifecycle install scripts from the package manifest.
+fn detect_install_scripts(extracted: &ExtractedPackage, registry: Registry) -> InstallScripts {
+    match registry {
+        Registry::Npm => {
+            let scripts = extracted
+                .manifest
+                .get("scripts")
+                .and_then(|s| s.as_object());
+            match scripts {
+                Some(s) => InstallScripts {
+                    preinstall: s.contains_key("preinstall"),
+                    install: s.contains_key("install"),
+                    postinstall: s.contains_key("postinstall"),
+                    prepare: s.contains_key("prepare"),
+                },
+                None => InstallScripts::default(),
+            }
+        }
+        Registry::Pypi => {
+            let mut scripts = InstallScripts::default();
+            for file in &extracted.source_files {
+                if file.path.ends_with("setup.py") {
+                    let content = &file.content;
+                    if content.contains("cmdclass") || content.contains("build_ext") {
+                        scripts.install = true;
+                    }
+                }
+            }
+            scripts
+        }
+        _ => InstallScripts::default(),
+    }
+}
+
 /// Main package scanner
 pub struct PackageScanner {
     db: Database,
@@ -605,6 +640,7 @@ impl PackageScanner {
         };
 
         let capabilities = capabilities.unwrap_or_default();
+        let install_scripts = detect_install_scripts(&extracted, registry);
 
         // Calculate trust score using adapter
         let trust_score = adapter.compute_trust_score(metadata);
@@ -663,6 +699,7 @@ impl PackageScanner {
                 maintainers: maintainers_json,
                 last_publish: metadata.published_at,
                 capabilities: serde_json::to_value(&capabilities)?,
+                install_scripts: serde_json::to_value(&install_scripts)?,
                 skill_md: Some(skill_md.clone()),
                 scan_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             })

--- a/migrations/20260218000001_add_install_scripts.sql
+++ b/migrations/20260218000001_add_install_scripts.sql
@@ -1,0 +1,2 @@
+-- Add install_scripts JSONB column to packages table
+ALTER TABLE packages ADD COLUMN IF NOT EXISTS install_scripts JSONB NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

The install_scripts field was hardcoded to empty defaults with a TODO comment. This adds end-to-end support: a new JSONB column in the packages table, detection of lifecycle hooks (preinstall, install, postinstall, prepare) from package.json during scans, and real values returned from all API endpoints.

## Why

<!-- Why is this needed? -->

Gives agents a notion about lifecycle attacks

## Test plan

- [x] Tests pass locally
- [x] Tested manually
