### PR TITLE
chore: bump version to v0.1.15 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           path: artifacts
 
+      - name: Delete existing release if present
+        run: gh release delete "${{ github.ref_name }}" --yes || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
         run: |
           gh release create "${{ github.ref_name }}" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 authors = ["brin contributors"]
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brin",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "the credit score for context — security scanning for packages, repos, MCP servers, skills, domains and commits",
   "bin": {
     "brin": "./bin/brin.js"


### PR DESCRIPTION
## What

<!-- Brief description of changes -->

Delete existing GitHub release before creating a new one to prevent failures on workflow re-runs.

## Why

<!-- Why is this needed? -->

## Test plan

- [x] Tests pass locally
- [x] Tested manually
